### PR TITLE
fix japanese support

### DIFF
--- a/dataParser/vendor/client/descriptionParser/manual-additions.json
+++ b/dataParser/vendor/client/descriptionParser/manual-additions.json
@@ -2,5 +2,6 @@
   "English": {},
   "Russian": {},
   "Korean": {},
-  "Traditional Chinese": {}
+  "Traditional Chinese": {},
+  "Japanese": {}
 }

--- a/dataParser/vendor/client/descriptionParser/overwrites.json
+++ b/dataParser/vendor/client/descriptionParser/overwrites.json
@@ -2,5 +2,6 @@
   "English": {},
   "Russian": {},
   "Korean": {},
-  "Traditional Chinese": {}
+  "Traditional Chinese": {},
+  "Japanese": {}
 }


### PR DESCRIPTION
Added missing parts of Japanese notation.

Also, I added "ja" to the end of lines:11 in #181 , but it's not there when I check it now. Was this intentional? If it was, there's no problem.

- \dataParser\vendor\pseudo-stats\add-to-new.py
Lines:11
```localizations = ["en", "ru", "ko", "cmn-Hant"]```
