### PR TITLE
[Parse Error] add missing translate

### DIFF
--- a/renderer/public/data/cmn-Hant/client_strings.js
+++ b/renderer/public/data/cmn-Hant/client_strings.js
@@ -108,7 +108,7 @@ export default {
   QUIVER_HELP_TEXT: '持弓時才可裝備',
   FLASK_HELP_TEXT: '右鍵點擊以喝下藥劑。',
   CHARM_HELP_TEXT: '達成特定條件時會自動使用。',
-  FIRE_DAMAGE: '',
-  LIGHTNING_DAMAGE: '',
-  COLD_DAMAGE: ''
+  FIRE_DAMAGE: '火焰傷害: ',
+  LIGHTNING_DAMAGE: '閃電傷害: ',
+  COLD_DAMAGE: '冰冷傷害: '
 }

--- a/renderer/public/data/ko/client_strings.js
+++ b/renderer/public/data/ko/client_strings.js
@@ -108,7 +108,7 @@ export default {
   QUIVER_HELP_TEXT: '활 장착',
   FLASK_HELP_TEXT: '마시려면 우클릭하십시오.',
   CHARM_HELP_TEXT: '조건이 충족되면 자동으로 ',
-  FIRE_DAMAGE: '',
-  LIGHTNING_DAMAGE: '',
-  COLD_DAMAGE: ''
+  FIRE_DAMAGE: '화염 피해: ',
+  LIGHTNING_DAMAGE: '냉기 피해: ',
+  COLD_DAMAGE: '번개 피해: '
 }


### PR DESCRIPTION
The missing translation will cause parse error when using different language, like #163.
It's root cause is `FIRE_DAMAGE` `LIGHTNING_DAMAGE` `COLD_DAMAGE` was used in `parseWeapon` function, leaving empty will cause the parser loop skip all parser after parseWeapon.

Note:
I can't read korean, so i need someone to double confirm the translation is corrected.