### PR TITLE
chore: yarn to npm and add missing step

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -43,10 +43,11 @@ npm run make-index-files
 npm run build
 
 cd ../main
+npm install
 npm run build
 # We want to sign with a distribution certificate to ensure other users can
 # install without errors
-CSC_NAME="Certificate name in Keychain" yarn package
+CSC_NAME="Certificate name in Keychain" npm run package
 ```
 
 # How to release a build


### PR DESCRIPTION
Fixed a minor issue I encountered while building this.

1. `renderer` and `main` have separate `package.json` files with separated `node_modules`. The repo isn't configured like a monorepo or with workspaces in a conventional sense, so we need to run `npm install` again when switching to the `main` directory.
2. Replace an instance of `yarn` with `npm`, since from what I can tell there's no need to use yarn here, so it's not worthwhile to jump between the package managers.

With these instructions, the build instructions work flawlessly now. 👍🏽