### PR TITLE
fix: update game config path for linux to poe2

### DIFF
--- a/main/src/host-files/GameConfig.ts
+++ b/main/src/host-files/GameConfig.ts
@@ -23,7 +23,7 @@ const POSSIBLE_PATH =
           ),
           path.join(
             app.getPath("home"),
-            ".local/share/Steam/steamapps/compatdata/238960/pfx/drive_c/users/steamuser/Documents/My Games/Path of Exile 2/poe2_production_Config.ini",
+            ".local/share/Steam/steamapps/compatdata/2694490/pfx/drive_c/users/steamuser/Documents/My Games/Path of Exile 2/poe2_production_Config.ini",
           ),
         ]
       : process.platform === "darwin"


### PR DESCRIPTION
The existing guessed locations for the POE configuration in Linux is pointing to the [POE1 238960](https://steamdb.info/app/238960/)  as opposed to [POE2 2694490](https://steamdb.info/app/2694490/).

Fixes #462.