### PR TITLE
feat: show possible values for stat tier in price check

### DIFF
--- a/renderer/src/web/price-check/filters/FilterModifierTiers.vue
+++ b/renderer/src/web/price-check/filters/FilterModifierTiers.vue
@@ -3,12 +3,9 @@
     v-if="tags.length"
     class="flex items-center text-xs leading-none gap-x-1"
   >
-    <span v-for="tag of tags" :class="$style[tag.type]"
-      >{{
-        t(tierOption == "poe2" ? "filters.tier" : "filters.grade", [tag.tier])
-      }}
-      {{ tag.range }}
-    </span>
+    <span v-for="tag of tags" :class="$style[tag.type]">{{
+      t(tierOption == "poe2" ? "filters.tier" : "filters.grade", [tag.tier])
+    }}</span>
   </div>
 </template>
 
@@ -50,7 +47,6 @@ export default defineComponent({
         tier: number | string;
         realTier: number;
         source: StatSource;
-        range: string;
       }> = [];
       for (const source of filter.sources) {
         const tier = source.modifier.info.tier;
@@ -58,18 +54,6 @@ export default defineComponent({
         if (!tier || !tierNew) continue;
         const usedTier: number | string =
           tierOption.value === "poe1" ? tier : tierNew;
-        const tryPercent = (val: number | undefined) =>
-          val === undefined
-            ? ""
-            : `${val}${filter.statRef.includes("#%") ? "%" : ""}`;
-        const min: string = tryPercent(source.contributes?.min);
-        const max: string = tryPercent(source.contributes?.max);
-        const range =
-          min === "" && max === ""
-            ? ""
-            : min === max
-              ? `(${min})`
-              : `(${min}-${max})`;
 
         if (
           (filter.tag === FilterTag.Explicit ||
@@ -85,7 +69,6 @@ export default defineComponent({
               tier: usedTier,
               realTier: tier,
               source,
-              range,
             });
           else if (tier === 2)
             out.push({
@@ -93,7 +76,6 @@ export default defineComponent({
               tier: usedTier,
               realTier: tier,
               source,
-              range,
             });
           else if (alwaysShowTier.value)
             out.push({
@@ -104,7 +86,6 @@ export default defineComponent({
                   : tierNew.toString() + ` [${tierNew + tier - 1}]`,
               realTier: tier,
               source,
-              range,
             });
         } else if (tier >= 2) {
           // fractured, explicit-* filters
@@ -113,7 +94,6 @@ export default defineComponent({
             tier: usedTier,
             realTier: tier,
             source,
-            range,
           });
         }
       }

--- a/renderer/src/web/price-check/filters/FilterModifierTiers.vue
+++ b/renderer/src/web/price-check/filters/FilterModifierTiers.vue
@@ -3,9 +3,12 @@
     v-if="tags.length"
     class="flex items-center text-xs leading-none gap-x-1"
   >
-    <span v-for="tag of tags" :class="$style[tag.type]">{{
-      t(tierOption == "poe2" ? "filters.tier" : "filters.grade", [tag.tier])
-    }}</span>
+    <span v-for="tag of tags" :class="$style[tag.type]"
+      >{{
+        t(tierOption == "poe2" ? "filters.tier" : "filters.grade", [tag.tier])
+      }}
+      {{ tag.range }}
+    </span>
   </div>
 </template>
 
@@ -47,6 +50,7 @@ export default defineComponent({
         tier: number | string;
         realTier: number;
         source: StatSource;
+        range: string;
       }> = [];
       for (const source of filter.sources) {
         const tier = source.modifier.info.tier;
@@ -54,6 +58,18 @@ export default defineComponent({
         if (!tier || !tierNew) continue;
         const usedTier: number | string =
           tierOption.value === "poe1" ? tier : tierNew;
+        const tryPercent = (val: number | undefined) =>
+          val === undefined
+            ? ""
+            : `${val}${filter.statRef.includes("#%") ? "%" : ""}`;
+        const min: string = tryPercent(source.contributes?.min);
+        const max: string = tryPercent(source.contributes?.max);
+        const range =
+          min === "" && max === ""
+            ? ""
+            : min === max
+              ? `(${min})`
+              : `(${min}-${max})`;
 
         if (
           (filter.tag === FilterTag.Explicit ||
@@ -69,6 +85,7 @@ export default defineComponent({
               tier: usedTier,
               realTier: tier,
               source,
+              range,
             });
           else if (tier === 2)
             out.push({
@@ -76,6 +93,7 @@ export default defineComponent({
               tier: usedTier,
               realTier: tier,
               source,
+              range,
             });
           else if (alwaysShowTier.value)
             out.push({
@@ -86,6 +104,7 @@ export default defineComponent({
                   : tierNew.toString() + ` [${tierNew + tier - 1}]`,
               realTier: tier,
               source,
+              range,
             });
         } else if (tier >= 2) {
           // fractured, explicit-* filters
@@ -94,6 +113,7 @@ export default defineComponent({
             tier: usedTier,
             realTier: tier,
             source,
+            range,
           });
         }
       }

--- a/renderer/src/web/price-check/filters/SourceInfo.vue
+++ b/renderer/src/web/price-check/filters/SourceInfo.vue
@@ -99,9 +99,12 @@ const stats = computed(() => {
     }
 
     const rollValue = parsed.roll.value * (parsed.translation.negate ? -1 : 1);
+    const min: number = parsed.roll.min;
+    const max: number = parsed.roll.max;
+    const range = min === max ? `` : ` (${min}-${max})`;
     return {
       text: parsed.translation.string,
-      roll: roundRoll(rollValue, parsed.roll.dp),
+      roll: roundRoll(rollValue, parsed.roll.dp) + range,
       contribution: contribution!,
       contributes: true,
     };

--- a/renderer/src/web/ui/ItemModifierText.vue
+++ b/renderer/src/web/ui/ItemModifierText.vue
@@ -17,7 +17,7 @@ import { computed } from "vue";
 
 const props = defineProps<{
   text: string;
-  roll?: number;
+  roll?: number | string;
 }>();
 
 const parts = computed(() => {


### PR DESCRIPTION
Solves #414 

- info is already available in the app from existing parsers,
- range is based on the game info, not our jsons,
- if stat ref (i.e. "X% increased critical hit chance") contains % it's added to the range,
- if for some reason game does not provide us with possible range, (x-y) part is not visible

![image](https://github.com/user-attachments/assets/cf676041-fdc6-4494-9a57-3288bc655457)
