### PR TITLE
fix: Default league to DoH instead of HC

### DIFF
--- a/renderer/src/web/background/Leagues.ts
+++ b/renderer/src/web/background/Leagues.ts
@@ -24,18 +24,18 @@ export const useLeagues = createGlobalState(() => {
   const tradeLeagues = shallowRef<League[]>([]);
 
   const DEFAULT_POE2_LEAGUES: ApiLeague[] = [
-    { id: "Standard", rules: [] },
+    { id: "Dawn of the Hunt", rules: [] },
     {
-      id: "Hardcore",
+      id: "HC Dawn of the Hunt",
       rules: [
         {
           id: "Hardcore",
         },
       ],
     },
-    { id: "Dawn of the Hunt", rules: [] },
+    { id: "Standard", rules: [] },
     {
-      id: "HC Dawn of the Hunt",
+      id: "Hardcore",
       rules: [
         {
           id: "Hardcore",
@@ -94,11 +94,11 @@ export const useLeagues = createGlobalState(() => {
         (league) => league.id === selectedId.value,
       );
       if (!leagueIsAlive && !isPrivateLeague(selectedId.value ?? "")) {
-        if (tradeLeagues.value.length > 2) {
-          const TMP_CHALLENGE = 2;
+        if (tradeLeagues.value.length > 1) {
+          const TMP_CHALLENGE = 0;
           selectedId.value = tradeLeagues.value[TMP_CHALLENGE].id;
         } else {
-          const STANDARD = 0;
+          const STANDARD = 2;
           selectedId.value = tradeLeagues.value[STANDARD].id;
         }
       }

--- a/renderer/src/web/background/Leagues.ts
+++ b/renderer/src/web/background/Leagues.ts
@@ -94,8 +94,8 @@ export const useLeagues = createGlobalState(() => {
         (league) => league.id === selectedId.value,
       );
       if (!leagueIsAlive && !isPrivateLeague(selectedId.value ?? "")) {
-        if (tradeLeagues.value.length > 1) {
-          const TMP_CHALLENGE = 1;
+        if (tradeLeagues.value.length > 2) {
+          const TMP_CHALLENGE = 2;
           selectedId.value = tradeLeagues.value[TMP_CHALLENGE].id;
         } else {
           const STANDARD = 0;


### PR DESCRIPTION
When a user does not have an appconfig the TMP_CHALLENGE was set to 1 which was being set to HC opposed to the primary new league Dawn of the Hunt (value 0 on GGG's website as well) 

Changed the leagues array, since the API seems to not fetch poe2 leagues properly still, to match GGG's trade site