### PR TITLE
Added an adapter to translate non-English, this allows non-English cl…

### DIFF
--- a/renderer/src/adapters/ISectionAdapter.ts
+++ b/renderer/src/adapters/ISectionAdapter.ts
@@ -1,0 +1,8 @@
+export interface ISectionAdapter {
+    transform(line: string): string;
+}
+
+export interface MappingRule {
+    pattern: RegExp;
+    replacement: string | ((match: RegExpMatchArray) => string);
+}

--- a/renderer/src/adapters/default.ts
+++ b/renderer/src/adapters/default.ts
@@ -1,0 +1,7 @@
+import { ISectionAdapter } from "./ISectionAdapter";
+
+export class DefaultAdapter implements ISectionAdapter {
+    transform(line: string): string {
+        return line;
+    }
+}

--- a/renderer/src/adapters/factory.ts
+++ b/renderer/src/adapters/factory.ts
@@ -1,0 +1,12 @@
+import { DefaultAdapter } from "./default";
+import { ISectionAdapter } from "./ISectionAdapter";
+import { ThaiAdapter } from "./thai";
+
+export function createAdapter(lang: string): ISectionAdapter {
+    switch (lang) {
+        case "th":
+            return new ThaiAdapter();
+        default:
+            return new DefaultAdapter(); // default adapter is just a simple passthrough
+    }
+}

--- a/renderer/src/adapters/thai.ts
+++ b/renderer/src/adapters/thai.ts
@@ -1,0 +1,159 @@
+import { ISectionAdapter, MappingRule } from "./ISectionAdapter";
+
+export class ThaiAdapter implements ISectionAdapter {
+    private rules: MappingRule[] = [
+        // Gears
+        {
+            pattern: /^ชนิดไอเทม: (.+)$/,
+            replacement: (_m) => `Item Class: ${ThaiAdapter.translateItemClass(_m[1])}`
+        },
+        {
+            pattern: /^ความหายาก: (.+)$/,
+            replacement: (_m) => `Rarity: ${ThaiAdapter.translateRarity(_m[1])}`
+        },
+        {
+            pattern: /^ต้องการ: เลเวล (.+)$/,
+            replacement: 'Requires: Level $1'
+        },
+        {
+            pattern: /^เลเวลไอเทม: (\d+)$/,
+            replacement: 'Item Level: $1'
+        },
+        {
+            pattern: /^ค่าคุณภาพ: (.+)$/,
+            replacement: 'Quality: $1'
+        },
+        {
+            pattern: /^อัตราการหลบหลีก: (.+)$/,
+            replacement: 'Evasion Rating: $1'
+        },
+        {
+            pattern: /^โล่พลังงาน: (.+)$/,
+            replacement: 'Energy Shield: $1'
+        },
+        {
+            pattern: /^รู: (.+)$/,
+            replacement: 'Sockets: $1'
+        },
+
+        // Implicits
+        {
+            pattern: /^เพิ่มความยากในการติดสถานะ สตัน (\d+)% \(implicit\)$/,
+            replacement: '$1% increased Stun Threshold (implicit)'
+        },
+
+        // Prefixes
+        {
+            pattern: /^พลังชีวิตสูงสุด \+(.+)$/,
+            replacement: '+$1 to maximum Life'
+        },
+        {
+            pattern: /^โล่พลังงานสูงสุด \+(.+)$/,
+            replacement: '+$1 to maximum Energy Shield'
+        },
+        {
+            pattern: /^อัตราการหลบหลีก \+(.+)$/,
+            replacement: '+$1 to Evasion Rating',
+        },
+        {
+            pattern: /^เพิ่มการหลบหลีกและโล่พลังงาน (.+)$/,
+            replacement: '$1 increased Evasion and Energy Shield',
+        },
+
+        // Suffixes
+        {
+            pattern: /^ค่าต้านทาน ไฟ \+(.+)%(.*)$/,
+            replacement: '+$1% to Fire Resistance$2'
+        },
+        {
+            pattern: /^ค่าต้านทาน น้ำแข็ง \+(.+)%(.*)$/,
+            replacement: '+$1% to Cold Resistance$2'
+        },
+        {
+            pattern: /^ค่าต้านทาน สายฟ้า \+(.+)%(.*)$/,
+            replacement: '+$1% to Lightning Resistance$2'
+        },
+        {
+            pattern: /^ค่าต้านทาน เคออส \+(.+)%(.*)$/,
+            replacement: '+$1% to Chaos Resistance$2'
+        },
+
+
+        // Runes
+        {
+            pattern: /^เพิ่มค่าเกราะ, การหลบหลีก, โล่พลังงาน (\d+)% \(rune\)$/,
+            replacement: '$1% increased Armour, Evasion and Energy Shield (rune)'
+        },
+
+        // Prefix/Suffix descriptor
+        {
+            pattern: /^\{\s*(ม็อดพรีฟิกซ์|ม็อดซัฟฟิกซ์)\s*"(.*)"*"\s*\(ระดับ:\s*(\d+)\)\s*—\s*(.*?)\s*\}$/,
+            replacement: (_m) => {
+                const identifier = _m[1];
+                const label = _m[2];
+                const tier = _m[3];
+                const descriptors = _m[4].split(',');
+
+                const translatedIdentifier =
+                    identifier == "ม็อดพรีฟิกซ์"
+                        ? "Prefix Modifier"
+                        : identifier == "ม็อดซัฟฟิกซ์"
+                            ? "Suffix Modifier"
+                            : identifier; // this is fucked.
+                            
+                const translatedDescriptors = descriptors.map(ThaiAdapter.translateDescriptor).join(', ');
+
+                return `{ ${translatedIdentifier} "${label}" (Tier: ${tier}) — ${translatedDescriptors} }`
+            },
+        },
+
+        // Default
+        {
+            pattern: /^([a-zA-Z]+) \+(\d+)$/, //probably not a good idea, but worth trying. just make sure that all language-specific rules are defined above.
+            replacement: '$1 to $2'
+        },
+    ];
+
+    transform(line: string): string {
+        try {
+            for (const rule of this.rules) {
+                const match = line.match(rule.pattern);
+
+                if (match) {
+                    if (typeof rule.replacement === 'function') {
+                        return rule.replacement(match);
+                    } else {
+                        return line.replace(rule.pattern, rule.replacement);
+                    }
+                }
+            }
+
+            return line;
+        } catch (err) {
+            console.error(err);
+            console.error(line);
+
+            throw err;
+        }
+    }
+
+    private static translateItemClass(text: string): string {
+        const map: Record<string, string> = {
+            'เข็มขัด': 'Belts',
+            'แหวน': 'Ring',
+        };
+        return map[text] || text;
+    }
+
+    private static translateRarity(text: string): string {
+        const map: Record<string, string> = {
+            'ยูนิค': 'Unique',
+            'แรร์': 'Rare',
+        };
+        return map[text] || text;
+    }
+
+    private static translateDescriptor(text: string): string {
+        return text;
+    }
+}

--- a/renderer/src/parser/Parser.ts
+++ b/renderer/src/parser/Parser.ts
@@ -39,6 +39,7 @@ import {
 } from "./advanced-mod-desc";
 import { calcPropPercentile, QUALITY_STATS } from "./calc-q20";
 import { getMaxTier } from "./mod-tiers";
+import { createAdapter } from "@/adapters/factory";
 
 type SectionParseResult =
   | "SECTION_PARSED"
@@ -167,10 +168,18 @@ function itemTextToSections(text: string) {
     lines.pop();
   }
 
+  // by keeping it as 'en' this will not affect the functionality of the parser until the adapters are implemented correctly.
+  const adapter = createAdapter("en");
+
   const sections: string[][] = [[]];
   lines.reduce((section, line) => {
+
+
     if (line !== "--------") {
-      section.push(line);
+      const transformedLine = adapter.transform(line);
+
+      section.push(transformedLine);
+
       return section;
     } else {
       const section: string[] = [];
@@ -178,6 +187,7 @@ function itemTextToSections(text: string) {
       return section;
     }
   }, sections[0]);
+
   return sections.filter((section) => section.length);
 }
 


### PR DESCRIPTION
Added an adapter to translate non-English, this allows non-English client to parse the clipboard correctly

Currently I'm forcing the factory to create a passthrough adapter to prevent it from breaking the existing functionality of the parser, this PR is aiming just to add the boilerplate for the language adapters.

An example of Thai language with the adapter will result in an English modifiers that can be used by the remaining workflow of the parsers (this is still a work in progress and will need a lot more of a regex mapping).

![image](https://github.com/user-attachments/assets/42dab02f-8ff4-436e-a4c0-9d93558a5c7a)
