### PR TITLE
Fix Price check of Non-Explicit Stats

### DIFF
--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -1088,14 +1088,14 @@ function tradeIdToQuery(
 
   // Handle non-explicit stats that share the same id pattern as explicit stats
   // e.g. "desecrated.stat_xxx" or "fractured.stat_xxx" -> "explicit.stat_xxx"
-  const nonExplicitStatPrefixes = ['desecrated', 'fractured'];
-  const isNonExplicitStat = nonExplicitStatPrefixes.some(prefix => tradeId.startsWith(`${prefix}.`));
-  if (isNonExplicitStat) {
+  const nonExplicitModifiers: ModifierType[] = [ModifierType.Desecrated, ModifierType.Fractured];
+  const isNonExplicitModifier = nonExplicitModifiers.some(prefix => tradeId.startsWith(`${prefix}.`));
+  if (isNonExplicitModifier) {
     // By searching explicit stats, we also get non-explicit stats included
     // This would give better results for the majority of players by not hiding
     // many trade listings when a non-explicit stat is rolled on an item.
     // See https://github.com/Kvan7/Exiled-Exchange-2/pull/593#issuecomment-3254698924
-    tradeId = tradeId.replace(/^[^.]+\./, 'explicit.'); // replace anything before the first dot
+    tradeId = tradeId.replace(/^[^.]+(?=\.)/, ModifierType.Explicit); // replace anything before the first dot
   }
 
   // NOTE: poe1 overrides, leaving until any for poe2 are added


### PR DESCRIPTION
# Non Explicit stat price check
Currently the price check for desecrated and fractured mods uses their direct stat, which filters the trade request to only that exact stat as follows:
<img width="756" height="366" alt="image" src="https://github.com/user-attachments/assets/f7befcbb-8d6f-43ad-95ee-b57ae47b9156" />

The issue here is that `desecrated` and maybe `fractured` (I've never seen one of these myself so can't check) have `explicit` counterparts that when searched on the Trade API will **also** return the non-`explicit` versions in results anyway.

This fix means the search includes all of the stat in the price check and results in this more accurate price check
<img width="752" height="321" alt="image" src="https://github.com/user-attachments/assets/03853ade-8662-45fc-a324-806e6def5248" />

### Updated
- Trade ID to Query now replaces specific non explicit modifiers with their explicit counterpart for **MUCH** more accurate price check results.

Downside here is people searching for _ONLY_ desecrated modifier for that stat can't do that via Exiled Exchange. It might be good in future to have some kind of setting or toggle per stat to modify this behaviour in the _rare_ case someone specifically needs a desecrated stat over an explicit one.

Massive thanks to @ellacroix for noting this in https://github.com/Kvan7/Exiled-Exchange-2/pull/593#issuecomment-3254698924 - it makes this change much easier!