### PR TITLE
Fix non English language Exceptional search

### DIFF
--- a/renderer/src/parser/Parser.ts
+++ b/renderer/src/parser/Parser.ts
@@ -1236,7 +1236,7 @@ function parseSuperior(item: ParserState) {
     (item.rarity === ItemRarity.Rare && item.isUnidentified) ||
     (item.rarity === ItemRarity.Unique && item.isUnidentified)
   ) {
-    if (_$.ITEM_SUPERIOR.test(item.name)) {
+    if (_$REF.ITEM_SUPERIOR.test(item.name)) {
       item.name = _$REF.ITEM_SUPERIOR.exec(item.name)![1];
     }
   }
@@ -1249,7 +1249,7 @@ function parseExceptional(item: ParserState) {
     (item.rarity === ItemRarity.Rare && item.isUnidentified) ||
     (item.rarity === ItemRarity.Unique && item.isUnidentified)
   ) {
-    if (_$.ITEM_EXCEPTIONAL.test(item.name)) {
+    if (_$REF.ITEM_EXCEPTIONAL.test(item.name)) {
       item.name = _$REF.ITEM_EXCEPTIONAL.exec(item.name)![1];
     }
   }


### PR DESCRIPTION
Fixes https://github.com/Kvan7/Exiled-Exchange-2/issues/603

Advanced copy for tools uses English localised text for item name, which should always use reference localisation (en)