### PR TITLE
Fix incorrect parsing for Fractured Item text

### DIFF
--- a/renderer/public/data/cmn-Hant/client_strings.js
+++ b/renderer/public/data/cmn-Hant/client_strings.js
@@ -124,5 +124,6 @@ export default {
   TIMELESS_SMALL_PASSIVES: '範圍內小型天賦也會賦予 {0}',
   TIMELESS_NOTABLE_PASSIVES: '範圍內核心天賦也會賦予 {0}',
   GRANTS_SKILL: '賦予技能: ',
-  RELOAD_SPEED: '重新裝填時間: '
+  RELOAD_SPEED: '重新裝填時間: ',
+  FRACTURED_ITEM: '破裂之物'
 }

--- a/renderer/public/data/de/client_strings.js
+++ b/renderer/public/data/de/client_strings.js
@@ -124,6 +124,7 @@ export default {
   TIMELESS_SMALL_PASSIVES: 'Kleine Passive Fertigkeiten im Radius gewähren auch {0}',
   TIMELESS_NOTABLE_PASSIVES: 'Bedeutende Passive Fertigkeiten im Radius gewähren auch {0}',
   GRANTS_SKILL: 'Gewährt Fertigkeit: ',
-  RELOAD_SPEED: 'Nachladezeit: '
+  RELOAD_SPEED: 'Nachladezeit: ',
+  FRACTURED_ITEM: 'Brüchiger Gegenstand'
 }
 

--- a/renderer/public/data/en/client_strings.js
+++ b/renderer/public/data/en/client_strings.js
@@ -225,5 +225,7 @@ export default {
   // ItemDisplayGrantsSkill
   GRANTS_SKILL: 'Grants Skill: ',
   // SkillPopupReloadTime
-  RELOAD_SPEED: 'Reload Time: '
+  RELOAD_SPEED: 'Reload Time: ',
+  // TODO CLIENT_STRINGS Id
+  FRACTURED_ITEM: 'Fractured Item'
 }

--- a/renderer/public/data/es/client_strings.js
+++ b/renderer/public/data/es/client_strings.js
@@ -123,5 +123,6 @@ export default {
   TIMELESS_SMALL_PASSIVES: 'Las habilidades pasivas pequeñas dentro del radio también otorgan {0}',
   TIMELESS_NOTABLE_PASSIVES: 'Las habilidades pasivas notables dentro del radio también otorgan {0}',
   GRANTS_SKILL: 'Otorga la habilidad: ',
-  RELOAD_SPEED: 'Tiempo de recarga: '
+  RELOAD_SPEED: 'Tiempo de recarga: ',
+  FRACTURED_ITEM: 'Objeto fracturado'
 }

--- a/renderer/public/data/ja/client_strings.js
+++ b/renderer/public/data/ja/client_strings.js
@@ -124,5 +124,6 @@ export default {
   TIMELESS_SMALL_PASSIVES: '範囲内の通常パッシブスキルは{0}も付与する',
   TIMELESS_NOTABLE_PASSIVES: '範囲内の特殊パッシブスキルは{0}も付与する',
   GRANTS_SKILL: 'スキルを付与: ',
-  RELOAD_SPEED: '再装填時間: '
+  RELOAD_SPEED: '再装填時間: ',
+  FRACTURED_ITEM: 'フラクチャーアイテム'
 }

--- a/renderer/public/data/ko/client_strings.js
+++ b/renderer/public/data/ko/client_strings.js
@@ -124,5 +124,6 @@ export default {
   TIMELESS_SMALL_PASSIVES: '반경 내 소형 패시브 스킬이 {0}도 부여',
   TIMELESS_NOTABLE_PASSIVES: '반경 내 주요 패시브 스킬이 {0}도 부여',
   GRANTS_SKILL: '스킬 부여: ',
-  RELOAD_SPEED: '재장전 시간: '
+  RELOAD_SPEED: '재장전 시간: ',
+  FRACTURED_ITEM: '분열된 아이템'
 }

--- a/renderer/public/data/pt/client_strings.js
+++ b/renderer/public/data/pt/client_strings.js
@@ -224,5 +224,6 @@ export default {
   TIMELESS_NOTABLE_PASSIVES: 'Habilidades Passivas Notáveis no Raio também concedem {0}',
   // ItemDisplayGrantsSkill
   GRANTS_SKILL: 'Concede Habilidade: ',
-  RELOAD_SPEED: 'Tempo de Recarregamento: '
+  RELOAD_SPEED: 'Tempo de Recarregamento: ',
+  FRACTURED_ITEM: 'Item Fixado'
 }

--- a/renderer/public/data/ru/client_strings.js
+++ b/renderer/public/data/ru/client_strings.js
@@ -158,5 +158,6 @@ export default {
   TIMELESS_SMALL_PASSIVES: 'Малые пассивные умения в радиусе также дают: {0}',
   TIMELESS_NOTABLE_PASSIVES: 'Значимые пассивные умения в радиусе также дают: {0}',
   GRANTS_SKILL: 'Дарует умение: ',
-  RELOAD_SPEED: 'Время перезарядки: '
+  RELOAD_SPEED: 'Время перезарядки: ',
+  FRACTURED_ITEM: 'Расколотый предмет'
 }

--- a/renderer/src/assets/data/interfaces.ts
+++ b/renderer/src/assets/data/interfaces.ts
@@ -231,6 +231,7 @@ export interface TranslationDict {
   TIMELESS_NOTABLE_PASSIVES: string;
   GRANTS_SKILL: string;
   RELOAD_SPEED: string;
+  FRACTURED_ITEM: string;
 }
 
 export interface Filter {

--- a/renderer/src/parser/Parser.ts
+++ b/renderer/src/parser/Parser.ts
@@ -64,7 +64,6 @@ const parsers: Array<ParserFn | { virtual: VirtualParserFn }> = [
   parseVaalGemName,
   { virtual: findInDatabase },
   // -----------
-  parseFracturedText,
   parseItemLevel,
   parseRequirements,
   parseTalismanTier,
@@ -78,6 +77,7 @@ const parsers: Array<ParserFn | { virtual: VirtualParserFn }> = [
   parseSpirit,
   parsePriceNote,
   parseUnneededText,
+  parseFracturedText,
   parseTimelostRadius,
   parseStackSize,
   parseCorrupted,

--- a/renderer/src/parser/Parser.ts
+++ b/renderer/src/parser/Parser.ts
@@ -146,7 +146,8 @@ export function parseClipboard(clipboard: string): Result<ParsedItem, string> {
         const result = parser(section, parsed.value);
         if (result === "SECTION_PARSED") {
           sections = sections.filter((s) => s !== section);
-          break;
+          // we don't break here since another section may be parsed by the same parser
+          // this still adheres to the rule of one parser per section
         } else if (result === "PARSER_SKIPPED") {
           break;
         }
@@ -1167,9 +1168,11 @@ function parseUnneededText(section: string[], item: ParsedItem) {
     item.category !== ItemCategory.Staff &&
     item.category !== ItemCategory.Shield &&
     item.category !== ItemCategory.Spear &&
-    item.category !== ItemCategory.Buckler
-  )
+    item.category !== ItemCategory.Buckler &&
+    item.category !== ItemCategory.Bow
+  ) {
     return "PARSER_SKIPPED";
+  }
 
   for (const line of section) {
     if (
@@ -1181,7 +1184,8 @@ function parseUnneededText(section: string[], item: ParsedItem) {
       line.startsWith(_$.SANCTUM_HELP) ||
       line.startsWith(_$.PRECURSOR_TABLET_HELP) ||
       line.startsWith(_$.LOGBOOK_HELP) ||
-      line.startsWith(_$.GRANTS_SKILL)
+      line.startsWith(_$.GRANTS_SKILL) ||
+      line.startsWith(_$.FRACTURED_ITEM)
     ) {
       return "SECTION_PARSED";
     }

--- a/renderer/src/parser/Parser.ts
+++ b/renderer/src/parser/Parser.ts
@@ -1177,9 +1177,8 @@ function parseUnneededText(section: string[], item: ParsedItem) {
     item.category !== ItemCategory.Shield &&
     item.category !== ItemCategory.Spear &&
     item.category !== ItemCategory.Buckler
-  ) {
+  )
     return "PARSER_SKIPPED";
-  }
 
   for (const line of section) {
     if (


### PR DESCRIPTION
Fixes https://github.com/Kvan7/Exiled-Exchange-2/issues/610

`Fractured Item` section appears to be new. It's not required for any useful info, so it was added to `parseUnneededText`. The issue there with specific items such as Sceptres with `Grants Skill:` text is that each parser in the current `master` release can only parse one section successfully, then the parser is exhausted.

There is a `// TODO CLIENT_STRINGS Id` comment @Kvan7 - since you have the Data Parser repository (private I think), it would be best to fill the Id of this piece of text in future, if you have it in your exports.

Updates:
- `parser` can now parse more than one section successfully, this does not break the `one parser per section` but rather allows multiple sections to be parsed by the _same_ parser. This is required for items with `Grants Skill:` as well as `Fractured Item` or other combinations.
- Localised `FRACTURED_ITEM` text added for all languages, and added to `parseUnneededText`.
- `Bow` category added to allowed categories parsed by `parseUnneededText`.

Tested with English, Japanese and Russian with a Fractured Sceptre:
```
Item Class: Sceptres
Rarity: Rare
Carrion Smasher
Rattling Sceptre
--------
Spirit: 122 (augmented)
--------
Requires: Level 72, 126 Int
--------
Item Level: 77
--------
Grants Skill: Level 17 Skeletal Warrior Minion
--------
{ Prefix Modifier "Blasting" (Tier: 2) — Damage, Elemental, Fire, Attack }
Allies in your Presence deal 24(20-24) to 32(31-38) added Attack Fire Damage (desecrated)
{ Prefix Modifier "Emissary's" (Tier: 5) }
22(19-22)% increased Spirit (desecrated)
+27(25-28) to maximum Mana (desecrated)
{ Prefix Modifier "Entombing" (Tier: 1) — Damage, Elemental, Cold, Attack }
Allies in your Presence deal 22(21-24) to 37(32-37) added Attack Cold Damage (desecrated)
{ Suffix Modifier "of the Director" (Tier: 4) — Life, Minion }
Minions have 35(31-35)% increased maximum Life (fractured)
{ Suffix Modifier "of the Taskmaster" (Tier: 4) — Minion, Gem }
+1 to Level of all Minion Skills (desecrated)
{ Suffix Modifier "of Disaster" (Tier: 4) — Critical }
Allies in your Presence have 24(20-24)% increased Critical Hit Chance (desecrated)
--------
Corrupted
--------
Fractured Item
```
<img width="860" height="1087" alt="image" src="https://github.com/user-attachments/assets/c0affe31-0212-4293-a120-0106da84a7bf" />
_English version, works with other locales too - translations were taken direct from Item Text in game for each language by manually changing client language_


Tested English with the Bow noted in issue 610:
<img width="854" height="1097" alt="image" src="https://github.com/user-attachments/assets/f33b8c4f-cea8-4e75-a914-1a48413218f0" />
_Forcing the clipboard with issue Item Text in English config_
