### PR TITLE
fix: Prevent focus stealing on Linux

### DIFF
--- a/main/src/windowing/OverlayWindow.ts
+++ b/main/src/windowing/OverlayWindow.ts
@@ -33,7 +33,7 @@ export class OverlayWindow {
 
     if (process.argv.includes("--no-overlay")) return;
 
-    this.window = new BrowserWindow({
+    const windowOpts: Electron.BrowserWindowConstructorOptions = {
       icon: path.join(__dirname, process.env.STATIC!, "icon.png"),
       ...OVERLAY_WINDOW_OPTS,
       width: 800,
@@ -43,7 +43,16 @@ export class OverlayWindow {
         webviewTag: true,
         spellcheck: false,
       },
-    });
+    };
+
+    // Linux/X11: Special window configuration
+    if (process.platform === "linux") {
+      windowOpts.skipTaskbar = true;
+      windowOpts.focusable = true;
+      windowOpts.type = 'notification';  // Best balance of focus handling and stability
+    }
+
+    this.window = new BrowserWindow(windowOpts);
 
     this.window.setMenu(
       Menu.buildFromTemplate([
@@ -63,6 +72,12 @@ export class OverlayWindow {
 
     this.window.webContents.setWindowOpenHandler((details) => {
       shell.openExternal(details.url);
+      // Linux: Return focus to game after external link
+      if (process.platform === "linux") {
+        setTimeout(() => {
+          OverlayController.focusTarget();
+        }, 100);
+      }
       return { action: "deny" };
     });
   }
@@ -87,6 +102,11 @@ export class OverlayWindow {
   assertOverlayActive = () => {
     if (!this.isInteractable) {
       this.isInteractable = true;
+      // Linux needs explicit focus management
+      if (process.platform === "linux" && this.window) {
+        this.window.setFocusable(true);
+        this.window.focus();
+      }
       OverlayController.activateOverlay();
       this.poeWindow.isActive = false;
     }
@@ -95,6 +115,10 @@ export class OverlayWindow {
   assertGameActive = () => {
     if (this.isInteractable) {
       this.isInteractable = false;
+      // Linux needs to release focus explicitly
+      if (process.platform === "linux" && this.window) {
+        this.window.setFocusable(false);
+      }
       OverlayController.focusTarget();
       this.poeWindow.isActive = true;
     }


### PR DESCRIPTION
## Summary
This PR fixes input focus stealing on Linux systems. The previous implementation had issues with maintaining focus which would present as the overlay capturing all input and preventing gameplay.

## Changes
- Changed window configuration on Linux to use `type: 'notification'` which provides the best balance of focus handling and stability
- Keep `focusable: true` in initial window options to ensure keyboard input works
- Explicitly manage focus state when toggling between game and overlay
- Simplified comments and removed unnecessary logic

## Technical Details
The `notification` window type on Linux:
- Maintains keyboard input reliably (unlike `dock` type which loses input after alt-tabbing)
- Properly handles focus switching between game and overlay
- Works correctly with the electron-overlay-window library

## Important Note for GNOME Users
⚠️ **GNOME users must configure their dock to use any setting except "Always Visible"**:
- ✅ "Auto-hide" works perfectly
- ✅ "Intelligently hide" works perfectly  
- ❌ "Always Visible" will cause overlay positioning issues in fullscreen windowed mode

This is a limitation with how GNOME's dock interacts with overlay windows. Setting the dock to auto-hide ensures the overlay can use the full screen space when the game is in fullscreen windowed mode. I tried SO many different ways to work around this and nothing worked properly.

## Testing
Tested on Pop!_OS 22.04 (Ubuntu-based) with GNOME 42.9:
- Keyboard input works correctly in overlay
- Focus switching between game and overlay works as expected
- No focus stealing occurs when overlay is inactive
- Overlay maintains functionality after alt-tabbing to browser and back

Fixes #299 (related to overlay interaction issues)