### PR TITLE
fix: Restore Linux overlay focus handling

### DIFF
--- a/main/src/windowing/OverlayWindow.ts
+++ b/main/src/windowing/OverlayWindow.ts
@@ -45,6 +45,13 @@ export class OverlayWindow {
       },
     };
 
+    // Linux/X11: Special window configuration for proper focus handling
+    if (process.platform === "linux") {
+      windowOpts.skipTaskbar = true;
+      windowOpts.focusable = true;
+      windowOpts.type = "notification";
+    }
+
     this.window = new BrowserWindow(windowOpts);
 
     this.window.setMenu(
@@ -92,6 +99,7 @@ export class OverlayWindow {
       this.isInteractable = true;
       // Linux needs explicit focus management
       if (process.platform === "linux" && this.window) {
+        this.window.setFocusable(true);
         this.window.focus();
       }
       OverlayController.activateOverlay();
@@ -104,7 +112,7 @@ export class OverlayWindow {
       this.isInteractable = false;
       // Linux needs to release focus explicitly
       if (process.platform === "linux" && this.window) {
-        this.window.blur();
+        this.window.setFocusable(false);
       }
       OverlayController.focusTarget();
       this.poeWindow.isActive = true;


### PR DESCRIPTION
This restores the Linux focus handling that got removed in de30c0b7.

## The problem

After that commit, the overlay only works once per session on Linux. Open it, use it, close it - fine. Open it again and clicks pass right through.

## The fix

Bringing back the three things that were removed:

1. `windowOpts.type = "notification"` - needed for proper window layering on Linux
2. `setFocusable(true)` before focusing the overlay
3. `setFocusable(false)` when returning focus to the game (instead of just `blur()`)

On XWayland, the compositor needs the focusable state explicitly set - just calling focus/blur isn't enough.

## Tested on

- KDE Plasma 6.5.3 (Wayland)
- CachyOS, kernel 6.17.9
- NVIDIA 4090

Works properly now - overlay responds to clicks every time, not just the first.

Fixes #788, should also fix #673 (same symptoms, same distro family).

This is basically restoring what #674 added to fix #299.