### PR TITLE
Parse meta gems that omit Item Class

### DIFF
--- a/renderer/specs/Parser/metaGemBug.test.ts
+++ b/renderer/specs/Parser/metaGemBug.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { setupTests } from "@specs/vitest.setup";
+import { init } from "@/assets/data";
+import { parseClipboard, ItemCategory } from "@/parser";
+
+describe("meta gems without item class", () => {
+  beforeEach(async () => {
+    setupTests();
+    await init("en");
+  });
+
+  it("parses Cast on Critical copied text that starts with Rarity", () => {
+    const result = parseClipboard(`Rarity: Gem
+Cast on Critical
+--------
+Buff, Persistent, Trigger, Meta
+Level: 19
+Quality: +20% (augmented)
+Reservation: 100 Spirit
+--------
+Requires: Level 84, 147 Int
+--------
+Sockets: G G G G G
+--------
+While active, gains Energy when you Critically Hit enemies and triggers socketed Spells on reaching maximum Energy.
+--------
+10% increased Reservation Efficiency
+Gains 1 Energy per Power of enemies you
+Critically Hit with Skills, modified by the percentage of the enemy's Ailment Threshold the Critical Hit will deal
+54% increased Energy gained
+Triggers all Socketed Spells and loses all Energy on reaching maximum Energy
+--------
+Support
+--------
+Has 10 maximum Energy per 0.1 seconds of base cast time of Socketed Spells
+Socketed Skills deal 20% less Damage
+--------
+Place one or more Skill Gems into this Meta Gem's sockets in the Skills Panel. The socketed Skills will be incorporated into the Meta Gem's effect.
+`);
+
+    expect(result.isOk()).toBe(true);
+    const item = result._unsafeUnwrap();
+    expect(item.category).toBe(ItemCategory.Gem);
+    expect(item.info.refName).toBe("Cast on Critical");
+    expect(item.gemLevel).toBe(19);
+  });
+});

--- a/renderer/src/parser/Parser.ts
+++ b/renderer/src/parser/Parser.ts
@@ -446,11 +446,15 @@ function pickCorrectVariant(item: ParserState) {
 function parseNamePlate(section: string[]) {
   performance.mark("parseNamePlate");
   let line = section.shift();
-  if (!line?.startsWith(_$.ITEM_CLASS)) {
+  if (line?.startsWith(_$.ITEM_CLASS)) {
+    line = section.shift();
+  } else if (
+    !line?.startsWith(_$.RARITY) ||
+    line.slice(_$.RARITY.length) !== _$.RARITY_GEM
+  ) {
     return err("item.parse_error");
   }
 
-  line = section.shift();
   let rarityText: string | undefined;
   if (line?.startsWith(_$.RARITY)) {
     rarityText = line.slice(_$.RARITY.length);


### PR DESCRIPTION
﻿## Summary

- Allow PoE2 gem clipboard text to start directly with `Rarity: Gem` when GGG omits the `Item Class:` line.
- Keep the fallback narrow: malformed non-gem item text still returns `item.parse_error`.
- Add a regression test using the `Cast on Critical` copied text from the issue.

Fixes #836.

## Why

The parser currently assumes the nameplate section always begins with `Item Class:`. Some PoE2 meta/spirit gems are copied without that line, so `parseNamePlate()` exits before gem parsing can identify the item.

The change only accepts the missing item-class path when the first line is explicitly `Rarity: Gem`, preserving strict handling for other malformed clipboard payloads.

## Validation

From `renderer`:

- `npm.cmd test -- specs/Parser/metaGemBug.test.ts specs/Parser/parsers.test.ts --run` — 31 tests passed
- `npm.cmd run check-types`
- `npm.cmd run lint`
