### PR TITLE
Make price-check default trade currency exalted_divine

### DIFF
--- a/renderer/src/web/price-check/trade/OnlineFilter.vue
+++ b/renderer/src/web/price-check/trade/OnlineFilter.vue
@@ -105,9 +105,12 @@
             <ui-radio v-model="filters.trade.currency" value="divine">{{
               t(":currency_only_div")
             }}</ui-radio>
-            <ui-radio v-model="filters.trade.currency" value="exalted_divine" :default="true">{{
-              t(":currency_exalted_div")
-            }}</ui-radio>
++            <ui-radio
+              v-model="filters.trade.currency"
+              value="exalted_divine"
+              :default="true"
+              >{{ t(":currency_exalted_div") }}</ui-radio
+            >
           </template>
         </div>
       </div>
@@ -153,7 +156,8 @@ export default defineComponent({
         Boolean(
           (props.filters.trade.listed &&
             ["1day", "3days", "1week"].includes(props.filters.trade.listed)) ||
-            (props.filters.trade.currency && props.filters.trade.currency !== "currency_any"),
+            (props.filters.trade.currency &&
+              props.filters.trade.currency !== "currency_any"),
         ),
       onOfflineUpdate(offline: boolean) {
         const { filters } = props;

--- a/renderer/src/web/price-check/trade/OnlineFilter.vue
+++ b/renderer/src/web/price-check/trade/OnlineFilter.vue
@@ -93,7 +93,7 @@
             <ui-radio
               class="mt-3"
               v-model="filters.trade.currency"
-              :value="undefined"
+              value="currency_any"
               >{{ t(":currency_any") }}</ui-radio
             >
             <ui-radio v-model="filters.trade.currency" value="exalted">{{
@@ -105,7 +105,7 @@
             <ui-radio v-model="filters.trade.currency" value="divine">{{
               t(":currency_only_div")
             }}</ui-radio>
-            <ui-radio v-model="filters.trade.currency" value="exalted_divine">{{
+            <ui-radio v-model="filters.trade.currency" value="exalted_divine" :default="true">{{
               t(":currency_exalted_div")
             }}</ui-radio>
           </template>
@@ -153,7 +153,7 @@ export default defineComponent({
         Boolean(
           (props.filters.trade.listed &&
             ["1day", "3days", "1week"].includes(props.filters.trade.listed)) ||
-            props.filters.trade.currency,
+            (props.filters.trade.currency && props.filters.trade.currency !== "currency_any"),
         ),
       onOfflineUpdate(offline: boolean) {
         const { filters } = props;

--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -568,7 +568,7 @@ export function createTradeRequest(
   };
   const { query } = body;
 
-  if (filters.trade.currency) {
+  if (filters.trade.currency && filters.trade.currency !== "currency_any") {
     propSet(
       query.filters,
       "trade_filters.filters.price.option",

--- a/renderer/src/web/ui/UiRadio.vue
+++ b/renderer/src/web/ui/UiRadio.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from "vue";
+import { defineComponent, computed, onMounted } from "vue";
 
 export default defineComponent({
   name: "UiRadio",
@@ -37,8 +37,18 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    default: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props, ctx) {
+    onMounted(() => {
+      if (props.default && props.modelValue === undefined && props.value !== undefined) {
+        ctx.emit("update:modelValue", props.value);
+      }
+    });
+
     return {
       isChecked: computed(() => {
         return props.modelValue === props.value;


### PR DESCRIPTION
I’m tired of seeing people try to sell items for weird currencies like Transmutes, Alterations, etc. This change makes the default trade currency exalted_divine in the price-check UI and updates UiRadio to support a default prop so a radio option can be marked as the default selection.