### PR TITLE
fix: stop echoing anonymous POESESSID to the trade API (Cloudflare challenges)

### DIFF
--- a/main/src/proxy.ts
+++ b/main/src/proxy.ts
@@ -49,7 +49,8 @@ export class HttpProxy {
           ...req.headers,
           "user-agent": app.userAgentFallback,
         },
-        useSessionCookies: true,
+        // no session cookies: echoing the anonymous POESESSID that the API
+        // itself sets triggers Cloudflare bot challenges
         referrerPolicy: "no-referrer-when-downgrade",
       });
       proxyReq.addListener("response", (proxyRes) => {


### PR DESCRIPTION
The 429s in #910 aren't rate limits - they're Cloudflare bot challenges (`cf-mitigated: challenge`, no `X-Rate-Limit-*` headers). GGG's trade API sets an anonymous POESESSID on its own responses, and Cloudflare challenges any `/api/trade2/*` request that echoes it back. With `useSessionCookies: true` the first API response of a session poisons the jar, so the first lookup works and everything after gets challenged.

Fix is to just not send session cookies from the proxy - nothing in EE2 needs them. Same fix shipped in Scalpel (scalpelpoe/scalpel@d22f3503): cookie-less requests passed 18/18 under burst load, cookie-carrying ones got challenged from request 2 on.

Fixes #910. I'll ping you on discord with the full debugging story.
