### PR TITLE
Show affix tiers in listing tooltips

### DIFF
--- a/renderer/specs/docs/fetchResponses.json
+++ b/renderer/specs/docs/fetchResponses.json
@@ -2915,6 +2915,337 @@
           }
         }
       }
+    },
+    {
+      "id": "2fa2f1ee71c3ed3e396180c3b5ef60a8948e1d09a76dbb3e3a7d85651a88cc43",
+      "listing": {
+        "method": "psapi",
+        "indexed": "2026-06-13T19:42:46Z",
+        "stash": {
+          "name": "5",
+          "x": 10,
+          "y": 8
+        },
+        "price": {
+          "type": "~b/o",
+          "amount": 3,
+          "currency": "divine"
+        },
+        "fee": 75269,
+        "account": {
+          "name": "Claazy#1164",
+          "online": null
+        }
+      },
+      "item": {
+        "realm": "poe2",
+        "verified": true,
+        "w": 2,
+        "h": 4,
+        "icon": "https://web.poecdn.com/gen/image/WzI1LDE0LHsiZiI6IjJESXRlbXMvV2VhcG9ucy9Ud29IYW5kV2VhcG9ucy9XYXJTdGF2ZXMvV2Fyc3RhZmYxMCIsInciOjIsImgiOjQsInNjYWxlIjoxLCJyZWFsbSI6InBvZTIifV0/d836b3566d/Warstaff10.png",
+        "league": "Runes of Aldur",
+        "id": "2fa2f1ee71c3ed3e396180c3b5ef60a8948e1d09a76dbb3e3a7d85651a88cc43",
+        "sockets": [
+          {
+            "group": 0,
+            "type": "rune"
+          },
+          {
+            "group": 1,
+            "type": "rune"
+          }
+        ],
+        "name": "Brood Pillar",
+        "typeLine": "Dreaming Quarterstaff",
+        "baseType": "Dreaming Quarterstaff",
+        "rarity": "Rare",
+        "ilvl": 81,
+        "identified": true,
+        "note": "~b/o 3 divine",
+        "properties": [
+          {
+            "name": "[Quarterstaff]",
+            "values": [],
+            "displayMode": 0,
+            "type": 109
+          },
+          {
+            "name": "[Quality]",
+            "values": [["+20%", 1]],
+            "displayMode": 0,
+            "type": 6
+          },
+          {
+            "name": "[Physical] Damage",
+            "values": [["454-639", 1]],
+            "displayMode": 0,
+            "type": 9
+          },
+          {
+            "name": "[Critical|Critical Hit] Chance",
+            "values": [["0.00%", 0]],
+            "displayMode": 0,
+            "type": 12
+          },
+          {
+            "name": "Attacks per Second",
+            "values": [["1.50", 0]],
+            "displayMode": 0,
+            "type": 13
+          }
+        ],
+        "requirements": [
+          {
+            "name": "Level",
+            "values": [["78", 0]],
+            "displayMode": 0,
+            "type": 62
+          },
+          {
+            "name": "[Dexterity|Dex]",
+            "values": [["127", 0]],
+            "displayMode": 1,
+            "type": 64
+          },
+          {
+            "name": "[Intelligence|Int]",
+            "values": [["50", 0]],
+            "displayMode": 1,
+            "type": 65
+          }
+        ],
+        "runeMods": [
+          "36% increased [Physical] Damage",
+          "[ShamanOnlyMods|Bonded]: 40% increased effect of [ArmourBreak|Fully Broken Armour]"
+        ],
+        "explicitMods": [
+          "199% increased [Physical] Damage",
+          "Adds 14 to 26 [Physical|Physical] Damage",
+          "+77 to [Accuracy|Accuracy] Rating",
+          "Gain 35 Life per enemy killed",
+          "Causes 43% increased [Stun|Stun] Buildup",
+          "18% increased [Stun|Stun] Duration"
+        ],
+        "frameType": 2,
+        "frameTypeId": "Rare",
+        "socketedItems": [
+          {
+            "realm": "poe2",
+            "verified": true,
+            "w": 1,
+            "h": 1,
+            "icon": "https://web.poecdn.com/gen/image/WzI1LDE0LHsiZiI6IjJESXRlbXMvQ3VycmVuY3kvUnVuZXMvRW5oYW5jZVJ1bmVUaWVyMiIsInciOjEsImgiOjEsInNjYWxlIjoxLCJyZWFsbSI6InBvZTIifV0/6b729ab5a0/EnhanceRuneTier2.png",
+            "stackSize": 1,
+            "maxStackSize": 10,
+            "league": "Runes of Aldur",
+            "id": "a25757280cf791009331bead1986fa1ac037246a0705ca75ccffd20d2acd6a4b",
+            "name": "",
+            "typeLine": "Greater Iron Rune",
+            "baseType": "Greater Iron Rune",
+            "ilvl": 0,
+            "identified": true,
+            "properties": [
+              {
+                "name": "Stack Size",
+                "values": [["1/10", 0]],
+                "displayMode": 0,
+                "type": 32
+              },
+              {
+                "name": "[Rune|Rune]",
+                "values": [],
+                "displayMode": 0
+              }
+            ],
+            "requirements": [
+              {
+                "name": "Level",
+                "values": [["30", 0]],
+                "displayMode": 0,
+                "type": 62
+              }
+            ],
+            "explicitMods": [
+              "[MartialWeapon|Martial Weapon]: 18% increased [Physical] Damage",
+              "Wand or Staff: 30% increased [Spell] Damage",
+              "Armour: 18% increased [Armour|Armour], [Evasion|Evasion] and [EnergyShield|Energy Shield]"
+            ],
+            "bondedMods": [
+              "[ShamanOnlyMods|Bonded]:",
+              "[MartialWeapon|Martial Weapon]: 20% increased effect of [ArmourBreak|Fully Broken Armour]",
+              "Wand or Staff: [ArmourBreak|Break] [Armour] on [Critical|Critical Hit] with [Spell|Spells] equal to 12% of [Physical|Physical] Damage dealt",
+              "Armour:",
+              "+20 to maximum Life",
+              "+20 to maximum Mana"
+            ],
+            "descrText": "Place into an empty [Augment] Socket in a Weapon or Armour to apply its effect to that item. Once socketed it cannot be retrieved but can be replaced by other [Augment] items.",
+            "frameType": 5,
+            "frameTypeId": "Currency",
+            "socket": 0,
+            "socketedIcon": "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9SdW5lU29ja2V0RmlsbGVkIiwicmVhbG0iOiJwb2UyIn1d/d02d26cbf0/RuneSocketFilled.png"
+          },
+          {
+            "realm": "poe2",
+            "verified": true,
+            "w": 1,
+            "h": 1,
+            "icon": "https://web.poecdn.com/gen/image/WzI1LDE0LHsiZiI6IjJESXRlbXMvQ3VycmVuY3kvUnVuZXMvRW5oYW5jZVJ1bmVUaWVyMiIsInciOjEsImgiOjEsInNjYWxlIjoxLCJyZWFsbSI6InBvZTIifV0/6b729ab5a0/EnhanceRuneTier2.png",
+            "stackSize": 1,
+            "maxStackSize": 10,
+            "league": "Runes of Aldur",
+            "id": "73a09aff72ac3ba7fd15a7686a6415c07092600704b31e8992b0aab7defb2201",
+            "name": "",
+            "typeLine": "Greater Iron Rune",
+            "baseType": "Greater Iron Rune",
+            "ilvl": 0,
+            "identified": true,
+            "properties": [
+              {
+                "name": "Stack Size",
+                "values": [["1/10", 0]],
+                "displayMode": 0,
+                "type": 32
+              },
+              {
+                "name": "[Rune|Rune]",
+                "values": [],
+                "displayMode": 0
+              }
+            ],
+            "requirements": [
+              {
+                "name": "Level",
+                "values": [["30", 0]],
+                "displayMode": 0,
+                "type": 62
+              }
+            ],
+            "explicitMods": [
+              "[MartialWeapon|Martial Weapon]: 18% increased [Physical] Damage",
+              "Wand or Staff: 30% increased [Spell] Damage",
+              "Armour: 18% increased [Armour|Armour], [Evasion|Evasion] and [EnergyShield|Energy Shield]"
+            ],
+            "bondedMods": [
+              "[ShamanOnlyMods|Bonded]:",
+              "[MartialWeapon|Martial Weapon]: 20% increased effect of [ArmourBreak|Fully Broken Armour]",
+              "Wand or Staff: [ArmourBreak|Break] [Armour] on [Critical|Critical Hit] with [Spell|Spells] equal to 12% of [Physical|Physical] Damage dealt",
+              "Armour:",
+              "+20 to maximum Life",
+              "+20 to maximum Mana"
+            ],
+            "descrText": "Place into an empty [Augment] Socket in a Weapon or Armour to apply its effect to that item. Once socketed it cannot be retrieved but can be replaced by other [Augment] items.",
+            "frameType": 5,
+            "frameTypeId": "Currency",
+            "socket": 1,
+            "socketedIcon": "https://web.poecdn.com/gen/image/WzIxLDE0LHsiayI6IjJEQXJ0L1VJSW1hZ2VzL0luR2FtZS9SdW5lU29ja2V0RmlsbGVkIiwicmVhbG0iOiJwb2UyIn1d/d02d26cbf0/RuneSocketFilled.png"
+          }
+        ],
+        "extended": {
+          "dps": 819.75,
+          "pdps": 819.75,
+          "edps": 0,
+          "mods": {
+            "explicit": [
+              {
+                "name": "Honed",
+                "tier": "P6",
+                "level": 33,
+                "magnitudes": [
+                  {
+                    "hash": "explicit.stat_1940865751",
+                    "min": "11",
+                    "max": "17"
+                  },
+                  {
+                    "hash": "explicit.stat_1940865751",
+                    "min": "20",
+                    "max": "30"
+                  }
+                ]
+              },
+              {
+                "name": "Tyrannical",
+                "tier": "P2",
+                "level": 75,
+                "magnitudes": [
+                  {
+                    "hash": "explicit.stat_1509134228",
+                    "min": "155",
+                    "max": "169"
+                  }
+                ]
+              },
+              {
+                "name": "Mercenary's",
+                "tier": "P5",
+                "level": 38,
+                "magnitudes": [
+                  {
+                    "hash": "explicit.stat_1509134228",
+                    "min": "35",
+                    "max": "44"
+                  },
+                  {
+                    "hash": "explicit.stat_691932474",
+                    "min": "73",
+                    "max": "97"
+                  }
+                ]
+              },
+              {
+                "name": "of Vanquishing",
+                "tier": "S4",
+                "level": 44,
+                "magnitudes": [
+                  {
+                    "hash": "explicit.stat_3695891184",
+                    "min": "29",
+                    "max": "40"
+                  }
+                ]
+              },
+              {
+                "name": "of the Boxer",
+                "tier": "S4",
+                "level": 30,
+                "magnitudes": [
+                  {
+                    "hash": "explicit.stat_791928121",
+                    "min": "41",
+                    "max": "50"
+                  }
+                ]
+              },
+              {
+                "name": "of Stunning",
+                "tier": "S4",
+                "level": 30,
+                "magnitudes": [
+                  {
+                    "hash": "explicit.stat_748522257",
+                    "min": "17",
+                    "max": "19"
+                  }
+                ]
+              }
+            ]
+          },
+          "hashes": {
+            "explicit": [
+              ["explicit.stat_1509134228", [1, 2]],
+              ["explicit.stat_1940865751", [0]],
+              ["explicit.stat_691932474", [2]],
+              ["explicit.stat_3695891184", [3]],
+              ["explicit.stat_791928121", [4]],
+              ["explicit.stat_748522257", [5]]
+            ],
+            "rune": [
+              ["rune.stat_1509134228", null],
+              ["rune.stat_1039491398", null]
+            ]
+          }
+        }
+      }
     }
   ]
 }

--- a/renderer/specs/web/price-check/trade/pathofexile-trade.test.ts
+++ b/renderer/specs/web/price-check/trade/pathofexile-trade.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import fs from "fs";
 import path from "path";
 import { init } from "@/assets/data";
-import { __testExports } from "@/web/price-check/trade/pathofexile-trade";
+import {
+  __testExports,
+  DisplayItemLine,
+} from "@/web/price-check/trade/pathofexile-trade";
 import { setupTests } from "@specs/vitest.setup";
 
 function getFetchResult(idPrefix: string) {
@@ -11,6 +14,9 @@ function getFetchResult(idPrefix: string) {
   return data.result.find((result: { id: string }) =>
     result.id.startsWith(idPrefix),
   );
+}
+function getTiers(lines: DisplayItemLine[] | undefined) {
+  return lines?.map((line) => line.tier);
 }
 
 describe("pathofexile-trade tooltip parsing", () => {
@@ -23,24 +29,35 @@ describe("pathofexile-trade tooltip parsing", () => {
     const displayItem = __testExports.parseFetchResult(
       getFetchResult("65c7c4e8"),
     );
+    const tiers = getTiers(displayItem.explicitMods);
 
-    expect(displayItem.explicitMods?.map((mod) => mod.tier)).toEqual([
-      "P2",
-      "S3",
-    ]);
+    expect(tiers).toEqual(["P2", "S3"]);
   });
 
   it("reuses the same affix tier for hybrid modifier lines", () => {
     const displayItem = __testExports.parseFetchResult(
       getFetchResult("ece06af2"),
     );
+    const tiers = getTiers(displayItem.explicitMods);
 
-    expect(displayItem.explicitMods?.map((mod) => mod.tier)).toEqual([
-      "P7",
-      "P7",
-      "P5",
-      "S5",
-      "S6",
-    ]);
+    expect(tiers).toEqual(["P7", "P7", "P5", "S5", "S6"]);
+  });
+
+  it("can do many tiers to one mod", () => {
+    const displayItem = __testExports.parseFetchResult(
+      getFetchResult("2fa2f1ee"),
+    );
+    const tiers = getTiers(displayItem.explicitMods);
+
+    expect(tiers).toEqual(["P2 + P5", "P6", "P5", "S4", "S4", "S4"]);
+  });
+
+  it("can do many mods from one tier", () => {
+    const displayItem = __testExports.parseFetchResult(
+      getFetchResult("91c9f13"),
+    );
+    const tiers = getTiers(displayItem.explicitMods);
+
+    expect(tiers).toEqual(["P19", "S1", "S1", "S1"]);
   });
 });

--- a/renderer/specs/web/price-check/trade/pathofexile-trade.test.ts
+++ b/renderer/specs/web/price-check/trade/pathofexile-trade.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+import { init } from "@/assets/data";
+import { __testExports } from "@/web/price-check/trade/pathofexile-trade";
+import { setupTests } from "@specs/vitest.setup";
+
+function getFetchResult(idPrefix: string) {
+  const filePath = path.resolve(__dirname, "../../../docs/fetchResponses.json");
+  const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  return data.result.find((result: { id: string }) =>
+    result.id.startsWith(idPrefix),
+  );
+}
+
+describe("pathofexile-trade tooltip parsing", () => {
+  beforeEach(async () => {
+    setupTests();
+    await init("en");
+  });
+
+  it("preserves affix tiers for listing tooltip modifiers", () => {
+    const displayItem = __testExports.parseFetchResult(
+      getFetchResult("65c7c4e8"),
+    );
+
+    expect(displayItem.explicitMods?.map((mod) => mod.affixTier)).toEqual([
+      "P2",
+      "S3",
+    ]);
+  });
+
+  it("reuses the same affix tier for hybrid modifier lines", () => {
+    const displayItem = __testExports.parseFetchResult(
+      getFetchResult("ece06af2"),
+    );
+
+    expect(displayItem.explicitMods?.map((mod) => mod.affixTier)).toEqual([
+      "P7",
+      "P7",
+      "P5",
+      "S5",
+      "S6",
+    ]);
+  });
+});

--- a/renderer/specs/web/price-check/trade/pathofexile-trade.test.ts
+++ b/renderer/specs/web/price-check/trade/pathofexile-trade.test.ts
@@ -24,7 +24,7 @@ describe("pathofexile-trade tooltip parsing", () => {
       getFetchResult("65c7c4e8"),
     );
 
-    expect(displayItem.explicitMods?.map((mod) => mod.affixTier)).toEqual([
+    expect(displayItem.explicitMods?.map((mod) => mod.tier)).toEqual([
       "P2",
       "S3",
     ]);
@@ -35,7 +35,7 @@ describe("pathofexile-trade tooltip parsing", () => {
       getFetchResult("ece06af2"),
     );
 
-    expect(displayItem.explicitMods?.map((mod) => mod.affixTier)).toEqual([
+    expect(displayItem.explicitMods?.map((mod) => mod.tier)).toEqual([
       "P7",
       "P7",
       "P5",

--- a/renderer/src/web/price-check/trade/TooltipItem.vue
+++ b/renderer/src/web/price-check/trade/TooltipItem.vue
@@ -32,12 +32,9 @@
             <div
               v-for="mod in section.content"
               :key="mod.text"
-              class="flex items-center justify-between"
+              class="flex items-center justify-between gap-1"
             >
               <span class="flex-grow text-center">
-                <span v-if="mod.affixTier" :class="$style['mod-tier']">{{
-                  mod.affixTier
-                }}</span>
                 <span
                   :class="
                     mod.value
@@ -52,6 +49,15 @@
                   >{{ mod.value }}</span
                 >
               </span>
+              <span
+                v-if="mod.tier"
+                :class="{
+                  'text-blue-300': mod.tier.startsWith('S'),
+                  'text-red-300': mod.tier.startsWith('P'),
+                }"
+              >
+                {{ mod.tier }}</span
+              >
             </div>
           </div>
           <template v-if="dividerVisible[index]">
@@ -171,10 +177,6 @@ export default defineComponent({
 <style lang="postcss" module>
 .mod {
   @apply text-sm;
-}
-
-.mod-tier {
-  @apply inline-block mr-1 align-middle font-sans text-xs text-gray-500;
 }
 
 .Rare-separator,

--- a/renderer/src/web/price-check/trade/TooltipItem.vue
+++ b/renderer/src/web/price-check/trade/TooltipItem.vue
@@ -35,6 +35,9 @@
               class="flex items-center justify-between"
             >
               <span class="flex-grow text-center">
+                <span v-if="mod.affixTier" :class="$style['mod-tier']">{{
+                  mod.affixTier
+                }}</span>
                 <span
                   :class="
                     mod.value
@@ -168,6 +171,10 @@ export default defineComponent({
 <style lang="postcss" module>
 .mod {
   @apply text-sm;
+}
+
+.mod-tier {
+  @apply inline-block mr-1 align-middle font-sans text-xs text-gray-500;
 }
 
 .Rare-separator,

--- a/renderer/src/web/price-check/trade/TradeItem.vue
+++ b/renderer/src/web/price-check/trade/TradeItem.vue
@@ -244,4 +244,8 @@ div[data-tippy-root] .tippy-box[data-theme~="item-tooltip"] {
 .tippy-box[data-theme~="item-tooltip"] .tippy-content {
   @apply p-0 w-fit h-fit;
 }
+
+.tippy-box[data-theme~="item-tooltip"] > .tippy-arrow::before {
+  @apply text-white;
+}
 </style>

--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -389,8 +389,6 @@ interface TradeModMetadata {
   magnitudes: Array<{ hash: string; min: string; max: string }>;
 }
 
-type TradeModHashes = Record<string, Array<Array<string | number[] | null>>>;
-
 interface TradeDataRichLine {
   name: string;
   values: Array<[string, TradeNumberColors]>;
@@ -442,24 +440,7 @@ interface FetchResult {
     mutatedMods?: string[];
     enchantMods?: string[];
     runeMods?: string[];
-    extended?: {
-      dps?: number;
-      pdps?: number;
-      edps?: number;
-      ar?: number;
-      ev?: number;
-      es?: number;
-      ward?: number;
-      dps_aug?: boolean;
-      pdps_aug?: boolean;
-      edps_aug?: boolean;
-      ar_aug?: boolean;
-      ev_aug?: boolean;
-      es_aug?: boolean;
-      ward_aug?: boolean;
-      mods?: Record<string, TradeModMetadata[]>;
-      hashes?: Record<string, Array<Array<string | number[] | null>>>;
-    };
+    extended?: FetchResultExtended;
     pseudoMods?: string[];
     desecratedMods?: string[];
     fracturedMods?: string[];
@@ -478,12 +459,33 @@ interface FetchResult {
   gone?: boolean;
 }
 
+export interface FetchResultExtended {
+  dps?: number;
+  pdps?: number;
+  edps?: number;
+  ar?: number;
+  ev?: number;
+  es?: number;
+  ward?: number;
+  dps_aug?: boolean;
+  pdps_aug?: boolean;
+  edps_aug?: boolean;
+  ar_aug?: boolean;
+  ev_aug?: boolean;
+  es_aug?: boolean;
+  ward_aug?: boolean;
+  mods?: Record<string, TradeModMetadata[]>;
+  hashes?: Record<string, TradeModHashes[]>;
+}
+
+export type TradeModHashes = Array<string | number[] | null>;
+
 export interface DisplayItemLine {
   // text should include colon if required...
   text: string;
+  tier?: string;
   value?: string | number;
   color: TradeNumberColors;
-  affixTier?: string;
 }
 export enum DisplayFrameType {
   Normal = 0,
@@ -1582,19 +1584,20 @@ function parseModBlock(
   translated: string[] | undefined,
   color: TradeNumberColors = TradeNumberColors.Augmented,
   mods?: TradeModMetadata[],
-  hashes?: TradeModHashes[string],
+  hashes?: TradeModHashes[],
 ): DisplayItemLine[] | undefined {
+  // separate function, allow doing complex parsing later if needed
   if (!translated) return undefined;
   return translated.map((s, index) => {
-    const affixTier = getAffixTier(index, mods, hashes);
-    return { text: parseAffixStrings(s), color, affixTier };
+    const tier = getTier(index, mods, hashes);
+    return { text: parseAffixStrings(s), color, tier };
   });
 }
 
-function getAffixTier(
+function getTier(
   displayIndex: number,
   mods?: TradeModMetadata[],
-  hashes?: TradeModHashes[string],
+  hashes?: TradeModHashes[],
 ): string | undefined {
   if (!mods?.length) return undefined;
 

--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -384,10 +384,12 @@ export interface SearchResult {
 
 interface TradeModMetadata {
   name: string;
-  tier: number;
+  tier: string;
   level: number;
   magnitudes: Array<{ hash: string; min: string; max: string }>;
 }
+
+type TradeModHashes = Record<string, Array<Array<string | number[] | null>>>;
 
 interface TradeDataRichLine {
   name: string;
@@ -481,6 +483,7 @@ export interface DisplayItemLine {
   text: string;
   value?: string | number;
   color: TradeNumberColors;
+  affixTier?: string;
 }
 export enum DisplayFrameType {
   Normal = 0,
@@ -1520,44 +1523,101 @@ function parseMods(result: FetchResult): {
   fracturedMods?: DisplayItemLine[] | undefined;
   pseudoMods?: DisplayItemLine[] | undefined;
 } {
-  /*
+  const modMetadata = result.item.extended?.mods;
+  const modHashes = result.item.extended?.hashes;
 
-  */
   return {
     enchantMods: parseModBlock(
       result.item.enchantMods,
       TradeNumberColors.Enchant,
+      modMetadata?.enchant,
+      modHashes?.enchant,
     ),
-    runeMods: parseModBlock(result.item.runeMods, TradeNumberColors.Enchant),
-    implicitMods: parseModBlock(result.item.implicitMods),
+    runeMods: parseModBlock(
+      result.item.runeMods,
+      TradeNumberColors.Enchant,
+      modMetadata?.rune,
+      modHashes?.rune,
+    ),
+    implicitMods: parseModBlock(
+      result.item.implicitMods,
+      undefined,
+      modMetadata?.implicit,
+      modHashes?.implicit,
+    ),
     fracturedMods: parseModBlock(
       result.item.fracturedMods,
       TradeNumberColors.Fractured,
+      modMetadata?.fractured,
+      modHashes?.fractured,
     ),
-    explicitMods: parseModBlock(result.item.explicitMods),
+    explicitMods: parseModBlock(
+      result.item.explicitMods,
+      undefined,
+      modMetadata?.explicit,
+      modHashes?.explicit,
+    ),
     desecratedMods: parseModBlock(
       result.item.desecratedMods,
       TradeNumberColors.Desecrated,
+      modMetadata?.desecrated,
+      modHashes?.desecrated,
     ),
     mutatedMods: parseModBlock(
       result.item.mutatedMods,
       TradeNumberColors.Mutated,
+      modMetadata?.mutated,
+      modHashes?.mutated,
     ),
-    pseudoMods: parseModBlock(result.item.pseudoMods),
+    pseudoMods: parseModBlock(
+      result.item.pseudoMods,
+      undefined,
+      modMetadata?.pseudo,
+      modHashes?.pseudo,
+    ),
   };
 }
 
 function parseModBlock(
   translated: string[] | undefined,
   color: TradeNumberColors = TradeNumberColors.Augmented,
-  // mods: TradeModMetadata[] | undefined,
-  // hashes: Array<Array<string | number[] | null>> | undefined,
+  mods?: TradeModMetadata[],
+  hashes?: TradeModHashes[string],
 ): DisplayItemLine[] | undefined {
-  // separate function, allow doing complex parsing later if needed
   if (!translated) return undefined;
-  return translated.map((s) => {
-    return { text: parseAffixStrings(s), color };
+  return translated.map((s, index) => {
+    const affixTier = getAffixTier(index, mods, hashes);
+    return { text: parseAffixStrings(s), color, affixTier };
   });
+}
+
+function getAffixTier(
+  displayIndex: number,
+  mods?: TradeModMetadata[],
+  hashes?: TradeModHashes[string],
+): string | undefined {
+  if (!mods?.length) return undefined;
+
+  const hashEntry = hashes?.[displayIndex];
+  if (hashEntry) {
+    const modIndexes = hashEntry.find(
+      (part): part is number[] =>
+        Array.isArray(part) && part.every((value) => typeof value === "number"),
+    );
+
+    return modIndexes
+      ?.map((modIndex) => normalizeAffixTier(mods[modIndex]?.tier))
+      .find((tier) => tier != null);
+  }
+
+  if (hashes?.length) return undefined;
+
+  return normalizeAffixTier(mods[displayIndex]?.tier);
+}
+
+function normalizeAffixTier(tier: string | undefined): string | undefined {
+  const normalized = tier?.trim().toUpperCase();
+  return normalized && /^[PS]\d+$/.test(normalized) ? normalized : undefined;
 }
 
 function buildNameBlock(

--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -389,6 +389,8 @@ interface TradeModMetadata {
   magnitudes: Array<{ hash: string; min: string; max: string }>;
 }
 
+export type TradeModHashes = [string, number[] | null];
+
 interface TradeDataRichLine {
   name: string;
   values: Array<[string, TradeNumberColors]>;
@@ -477,8 +479,6 @@ export interface FetchResultExtended {
   mods?: Record<string, TradeModMetadata[]>;
   hashes?: Record<string, TradeModHashes[]>;
 }
-
-export type TradeModHashes = Array<string | number[] | null>;
 
 export interface DisplayItemLine {
   // text should include colon if required...
@@ -1599,28 +1599,18 @@ function getTier(
   mods?: TradeModMetadata[],
   hashes?: TradeModHashes[],
 ): string | undefined {
-  if (!mods?.length) return undefined;
+  if (!mods?.length) return;
 
   const hashEntry = hashes?.[displayIndex];
-  if (hashEntry) {
-    const modIndexes = hashEntry.find(
-      (part): part is number[] =>
-        Array.isArray(part) && part.every((value) => typeof value === "number"),
-    );
+  if (!hashEntry) return;
 
-    return modIndexes
-      ?.map((modIndex) => normalizeAffixTier(mods[modIndex]?.tier))
-      .find((tier) => tier != null);
-  }
+  const modIndexes = hashEntry[1];
+  if (!modIndexes) return;
 
-  if (hashes?.length) return undefined;
-
-  return normalizeAffixTier(mods[displayIndex]?.tier);
-}
-
-function normalizeAffixTier(tier: string | undefined): string | undefined {
-  const normalized = tier?.trim().toUpperCase();
-  return normalized && /^[PS]\d+$/.test(normalized) ? normalized : undefined;
+  return modIndexes
+    .map((modIndex) => mods[modIndex]?.tier)
+    .filter((tier) => tier != null)
+    .join(" + ");
 }
 
 function buildNameBlock(


### PR DESCRIPTION
Fixes #946

This adds the prefix/suffix tier marker from the trade fetch response to listing item tooltips, so price-check results show values like `P2` and `S3` before the matching modifier lines.

The main bug was that the fetch result already included the tier metadata in `item.extended.mods`, but the tooltip parser dropped it when converting the trade response into `displayItem`. I also avoided matching by array order, since the modifier metadata can be ordered differently from the displayed modifier lines. Instead, the parser uses `item.extended.hashes` to map each displayed line back to the correct modifier metadata, which also keeps hybrid mods lined up.

Validation run locally:

- `npm test -- --run specs/web/price-check/trade/pathofexile-trade.test.ts`
- `npm run check-types`
- `npm run lint`
- `npm run build`

I also checked the broader renderer test failures against upstream `master` at `006aa1ce`, before this patch. Representative failures in `specs/data/dataLoader.test.ts`, `specs/Parser/magic-name.test.ts`, and `specs/web/price-check/filters/pseudo/index.test.ts` reproduce there, so they are not caused by this change.