### PR TITLE
Global Hotkeys for Linux Wayland

### DIFF
--- a/docs/linux-evdev-helper.md
+++ b/docs/linux-evdev-helper.md
@@ -1,0 +1,133 @@
+# Linux evdev hotkey helper
+
+Exiled Exchange 2 normally uses Electron global shortcuts for app hotkeys. On
+Wayland, global hotkeys are compositor and portal dependent, and shortcuts can
+fail while Path of Exile has focus. The optional `linux-evdev-helper` backend
+delegates hotkey capture to a small native helper that reads configured
+`/dev/input/event*` keyboard devices with evdev.
+
+This backend is Linux-only and opt-in. The Electron/Node process does not read
+input devices directly and must not be run as root. The native helper runs as
+root by default through an explicit privilege prompt, then reports only
+configured hotkey activations to Node over stdout as newline-delimited JSON.
+
+## Build
+
+From the `main` package:
+
+```sh
+npm run build:linux-evdev-helper
+```
+
+Or directly:
+
+```sh
+make -C native/linux-evdev-helper
+```
+
+The helper has no Node, Electron, X11, Wayland, DBus, ncurses, GTK, or Qt
+dependency. It uses C11, libc, and Linux input headers.
+
+## Enable
+
+The app keeps the existing shortcut backend unless this backend is configured
+or the normal backend fails and this backend has a config.
+
+Hidden config example:
+
+```json
+{
+  "linuxShortcutBackend": {
+    "backend": "linux-evdev-helper",
+    "mode": "enabled",
+    "elevation": "pkexec",
+    "helperPath": "/absolute/path/to/linux-evdev-helper",
+    "devices": ["/dev/input/event4", "/dev/input/event7"],
+    "enableUinput": false
+  }
+}
+```
+
+`mode` defaults to `enabled`. Use `"fallback"` to try Electron global shortcuts
+first and start the helper only when registration fails.
+
+`elevation` defaults to `pkexec`, which opens a desktop authorization prompt
+and runs only the helper as root. Use `"sudo"` only when `SUDO_ASKPASS` is
+configured, because the app launches helpers in the background and cannot
+service an interactive terminal password prompt. `"none"` is available only for
+development or systems where device permissions are handled another way.
+
+For development, the renderer can also pass the backend from Vite env vars:
+
+```sh
+VITE_LINUX_HOTKEY_BACKEND=linux-evdev-helper \
+VITE_LINUX_HOTKEY_BACKEND_MODE=enabled \
+VITE_LINUX_HOTKEY_ELEVATION=pkexec \
+VITE_LINUX_HOTKEY_DEVICES=/dev/input/event4,/dev/input/event7 \
+VITE_LINUX_HOTKEY_HELPER=/absolute/path/to/linux-evdev-helper \
+npm run dev
+```
+
+If `hotkeys` is omitted, the app sends its current configured app hotkeys to the
+helper. If `hotkeys` is supplied, Node intersects that list with the current app
+hotkeys before launching the helper. Unknown or stale accelerators are not sent
+to the helper, so the helper can emit only app-owned shortcut activations.
+
+## Runtime hotkey changes
+
+The helper configuration is one-shot by design. Node sends the active hotkey set
+as JSON on stdin when the helper starts, then the helper emits only matching
+activation events on stdout.
+
+When the user changes hotkey settings while the game is active, the app stops
+the current helper process and starts a new one with the freshly derived app
+hotkey set. With the default `pkexec` elevation, this can show a privilege
+prompt at app startup and after each active settings change. The helper does
+not accept a general command channel and cannot be asked to run commands or
+register arbitrary shortcuts after startup.
+
+## Permissions
+
+The helper must run as root. Do not run the Electron app as root, and do not
+`chmod` input devices from JavaScript. By default, Node starts the helper with:
+
+```sh
+pkexec /absolute/path/to/linux-evdev-helper
+```
+
+For `elevation: "sudo"`, Node starts:
+
+```sh
+sudo -A /absolute/path/to/linux-evdev-helper
+```
+
+That requires `SUDO_ASKPASS` to be set to a graphical askpass helper.
+
+Alternative group-based device access can still be used with
+`elevation: "none"` for local development:
+
+Example group-based udev rule, adjust group and device match for your system:
+
+```udev
+SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_KEYBOARD}=="1", GROUP="input", MODE="0640"
+```
+
+Then add your user to that group and re-login. This project does not install
+udev rules automatically.
+
+Check access with:
+
+```sh
+printf '%s\n' '{"devices":["/dev/input/event4"],"hotkeys":[{"id":"price-check","accelerator":"Ctrl + D","key":"D","ctrl":true,"shift":false,"alt":false,"meta":false}]}' \
+  | pkexec native/linux-evdev-helper/linux-evdev-helper --check-permissions
+```
+
+## Limitations
+
+- Linux only.
+- Helper must run as root to read configured keyboard event devices.
+- Does not solve overlay stacking or compositor-specific focus behavior.
+- Ignores evdev repeat events; activations are emitted once on key press.
+- uinput injection is not implemented in this pass. If added later, it should
+  remain disabled by default, require `/dev/uinput` permissions, and expose only
+  narrow configured sequences such as `Ctrl+C`.

--- a/ipc/types.ts
+++ b/ipc/types.ts
@@ -1,5 +1,6 @@
 export interface HostConfig {
   shortcuts: ShortcutAction[];
+  linuxShortcutBackend?: LinuxShortcutBackendConfig;
   restoreClipboard: boolean;
   clientLog: string | null;
   gameConfig: string | null;
@@ -12,6 +13,43 @@ export interface HostConfig {
   libraryAlpha: boolean;
   libraryOutputPath: string | null;
   initialDelay: number;
+}
+
+export interface LinuxShortcutBackendConfig {
+  backend: "linux-evdev-helper";
+  mode?: "enabled" | "fallback";
+  elevation?: "pkexec" | "sudo" | "none";
+  helperPath?: string;
+  devices?: string[];
+  hotkeys?: Array<{
+    id: string;
+    accelerator: string;
+    passthrough?: boolean;
+  }>;
+  enableUinput?: false;
+}
+
+export interface LinuxHotkeyHelperStatus {
+  isWayland: boolean;
+  configured: boolean;
+  running: boolean;
+  elevation: "pkexec" | "sudo" | "none";
+  command: string | null;
+  capturing: string[];
+  error: string | null;
+}
+
+export interface LinuxHotkeyHelperDebugEvent {
+  kind: "start" | "ready" | "hotkey" | "error" | "exit";
+  at: number;
+  message: string;
+  id?: string;
+  accelerator?: string;
+  helperTs?: number;
+  code?: string;
+  device?: string;
+  exitCode?: number | null;
+  signal?: string | null;
 }
 
 export interface ShortcutAction {
@@ -70,6 +108,7 @@ export interface HostState {
   contents: string | null;
   version: string;
   updater: UpdateInfo;
+  linuxHotkeyHelper: LinuxHotkeyHelperStatus;
 }
 
 export type IpcEvent =
@@ -86,8 +125,11 @@ export type IpcEvent =
   | IpcGameLog
   | IpcClientIsActive
   | IpcLogEntry
+  | IpcLinuxHotkeyHelperState
+  | IpcLinuxHotkeyHelperDebugEvent
   | IpcHostConfig
   | IpcWidgetAction
+  | IpcOpenSettings
   | IpcItemText
   | IpcOcrText
   | IpcConfigChanged
@@ -171,6 +213,8 @@ type IpcWidgetAction = Event<
   }
 >;
 
+type IpcOpenSettings = Event<"MAIN->CLIENT::open-settings">;
+
 type IpcItemText = Event<
   "MAIN->CLIENT::item-text",
   {
@@ -203,12 +247,26 @@ type IpcReparseLog = Event<"CLIENT->MAIN::re-parse-log">;
 
 type IpcUpdaterState = Event<"MAIN->CLIENT::updater-state", UpdateInfo>;
 
+type IpcLinuxHotkeyHelperState = Event<
+  "MAIN->CLIENT::linux-hotkey-helper-state",
+  LinuxHotkeyHelperStatus
+>;
+
+type IpcLinuxHotkeyHelperDebugEvent = Event<
+  "MAIN->CLIENT::linux-hotkey-helper-debug-event",
+  LinuxHotkeyHelperDebugEvent
+>;
+
 // Hotkeyable actions are defined in `ShortcutAction`.
 // Actions below are triggered by user interaction with the UI.
 type IpcUserAction = Event<
   "CLIENT->MAIN::user-action",
   | {
-      action: "check-for-update" | "update-and-restart" | "quit";
+      action:
+        | "check-for-update"
+        | "update-and-restart"
+        | "quit"
+        | "restart-linux-hotkey-helper";
     }
   | {
       action: "stash-search";

--- a/main/build/script.mjs
+++ b/main/build/script.mjs
@@ -1,8 +1,11 @@
 import child_process from 'child_process'
 import electron from 'electron'
 import esbuild from 'esbuild'
+import fs from 'node:fs'
+import path from 'node:path'
 
 const isDev = !process.argv.includes('--prod')
+const devServerUrl = process.env.VITE_DEV_SERVER_URL || 'http://127.0.0.1:5173'
 
 const electronRunner = (() => {
   let handle = null
@@ -25,6 +28,15 @@ const visionBuild = await esbuild.build({
   outfile: 'dist/vision.js'
 })
 
+const linuxHelper = path.resolve('../native/linux-evdev-helper/linux-evdev-helper')
+if (process.platform === 'linux' && fs.existsSync(linuxHelper)) {
+  const dest = 'dist/linux-evdev-helper'
+  const temp = `${dest}.${process.pid}.tmp`
+  fs.copyFileSync(linuxHelper, temp)
+  fs.chmodSync(temp, 0o755)
+  fs.renameSync(temp, dest)
+}
+
 const mainContext = await esbuild.context({
   entryPoints: ['src/main.ts'],
   bundle: true,
@@ -34,7 +46,7 @@ const mainContext = await esbuild.context({
   outfile: 'dist/main.js',
   define: {
     'process.env.STATIC': (isDev) ? '"../build/icons"' : '"."',
-    'process.env.VITE_DEV_SERVER_URL': (isDev) ? '"http://localhost:5173"' : 'null'
+    'process.env.VITE_DEV_SERVER_URL': (isDev) ? JSON.stringify(devServerUrl) : 'null'
   },
   plugins: (isDev) ? [{
     name: 'electron-runner',

--- a/main/electron-builder.yml
+++ b/main/electron-builder.yml
@@ -2,11 +2,13 @@ publish:
   - "github"
 productName: "Exiled Exchange 2"
 npmRebuild: false
+asarUnpack:
+  - "linux-evdev-helper"
 files:
   - "package.json"
   - from: "dist"
     to: "."
-    filter: ["main.js", "vision.js"]
+    filter: ["main.js", "vision.js", "linux-evdev-helper"]
   - from: "../renderer/dist"
     to: "."
 extraMetadata:

--- a/main/package.json
+++ b/main/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "node build/script.mjs",
     "build": "tsc --noEmit && node build/script.mjs --prod",
+    "build:linux-evdev-helper": "make -C ../native/linux-evdev-helper",
+    "test:linux-evdev-helper": "node scripts/test-linux-evdev-helper.mjs",
     "package": "electron-builder build",
     "lint": "eslint src",
     "fix": "eslint src --fix",

--- a/main/scripts/test-linux-evdev-helper.mjs
+++ b/main/scripts/test-linux-evdev-helper.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function argValue(name) {
+  const prefix = `${name}=`;
+  const arg = process.argv.slice(2).find((value) => value.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : undefined;
+}
+
+function splitList(value) {
+  return value
+    ? value
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean)
+    : [];
+}
+
+function defaultConfigPath() {
+  return path.join(
+    os.homedir(),
+    ".config",
+    "exiled-exchange-2",
+    "apt-data",
+    "config.json",
+  );
+}
+
+function defaultHelperPath() {
+  const helperName = process.argv.includes("--debug-events")
+    ? "linux-evdev-helper-debug"
+    : "linux-evdev-helper";
+  const source = path.resolve(rootDir, "..", "native", "linux-evdev-helper", helperName);
+  if (fs.existsSync(source)) return source;
+  return path.resolve(rootDir, "dist", helperName);
+}
+
+function discoverKeyboardEventDevices() {
+  const devices = new Set();
+  if (process.argv.includes("--all-devices")) {
+    try {
+      for (const entry of fs.readdirSync("/dev/input")) {
+        if (/^event[0-9]+$/.test(entry)) devices.add(path.join("/dev/input", entry));
+      }
+    } catch {}
+    return Array.from(devices).sort();
+  }
+
+  for (const dir of ["/dev/input/by-path", "/dev/input/by-id"]) {
+    try {
+      for (const entry of fs.readdirSync(dir)) {
+        if (!entry.endsWith("-event-kbd")) continue;
+        const device = fs.realpathSync(path.join(dir, entry));
+        if (/^\/dev\/input\/event[0-9]+$/.test(device)) devices.add(device);
+      }
+    } catch {}
+  }
+
+  if (!devices.size) {
+    try {
+      for (const entry of fs.readdirSync("/dev/input")) {
+        if (/^event[0-9]+$/.test(entry)) devices.add(path.join("/dev/input", entry));
+      }
+    } catch {}
+  }
+
+  return Array.from(devices).sort();
+}
+
+function normalizeKey(key) {
+  const aliases = new Map([
+    ["Esc", "Escape"],
+    ["Del", "Delete"],
+    ["Ins", "Insert"],
+    ["Return", "Enter"],
+    ["Left", "ArrowLeft"],
+    ["Right", "ArrowRight"],
+    ["Up", "ArrowUp"],
+    ["Down", "ArrowDown"],
+    [".", "Period"],
+    [",", "Comma"],
+    ["/", "Slash"],
+    ["\\", "Backslash"],
+    ["-", "Minus"],
+    ["=", "Equal"],
+    ["`", "Backquote"],
+    ["'", "Quote"],
+    [";", "Semicolon"],
+    ["[", "BracketLeft"],
+    ["]", "BracketRight"],
+  ]);
+
+  if (aliases.has(key)) return aliases.get(key);
+  if (/^[a-z]$/.test(key)) return key.toUpperCase();
+  return key;
+}
+
+function parseAccelerator(accelerator) {
+  const parts = accelerator
+    .split("+")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const mods = {
+    ctrl: false,
+    shift: false,
+    alt: false,
+    meta: false,
+  };
+  let key = null;
+
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (lower === "ctrl" || lower === "control" || lower === "cmdorctrl") mods.ctrl = true;
+    else if (lower === "shift") mods.shift = true;
+    else if (lower === "alt" || lower === "option") mods.alt = true;
+    else if (lower === "super" || lower === "meta" || lower === "cmd" || lower === "command") mods.meta = true;
+    else if (key == null) key = normalizeKey(part);
+    else throw new Error(`unsupported accelerator with multiple non-modifier keys: ${accelerator}`);
+  }
+
+  if (!key) throw new Error(`modifier-only accelerator is not supported: ${accelerator}`);
+
+  const normalized = [
+    mods.ctrl ? "Ctrl" : null,
+    mods.shift ? "Shift" : null,
+    mods.alt ? "Alt" : null,
+    mods.meta ? "Super" : null,
+    key,
+  ]
+    .filter(Boolean)
+    .join(" + ");
+
+  return { accelerator: normalized, key, ...mods };
+}
+
+function addAction(actions, shortcut, id, type) {
+  if (!shortcut || typeof shortcut !== "string" || shortcut.trim() === "") return;
+  actions.push({ id, shortcut: shortcut.trim(), type });
+}
+
+function actionsFromConfig(config) {
+  const actions = [];
+  addAction(actions, config.overlayKey, "overlay", "toggle-overlay");
+
+  for (const widget of config.widgets ?? []) {
+    if (widget.wmType === "price-check") {
+      const hold = widget.hotkeyHold ? `${widget.hotkeyHold} + ` : "";
+      addAction(actions, `${hold}${widget.hotkey}`, "price-check", "copy-item");
+      addAction(actions, widget.hotkeyLocked, "price-check-locked", "copy-item");
+    } else if (widget.wmType === "item-check") {
+      addAction(actions, widget.hotkey, "item-check", "trigger-event");
+    } else if (widget.wmType === "delve-grid") {
+      addAction(actions, widget.toggleKey, "delve-grid", "trigger-event");
+    } else if (widget.wmType === "stash-search") {
+      for (const [index, entry] of (widget.entries ?? []).entries()) {
+        addAction(actions, entry.hotkey, `stash-search-${index}`, "stash-search");
+      }
+    } else if (widget.wmType === "timer") {
+      addAction(actions, widget.toggleKey, `timer-toggle-${widget.wmId}`, "trigger-event");
+      addAction(actions, widget.resetKey, `timer-reset-${widget.wmId}`, "trigger-event");
+    } else if (widget.wmType === "item-search") {
+      addAction(actions, widget.ocrGemsKey, "ocr-gems", "ocr-text");
+    }
+  }
+
+  const byShortcut = new Map();
+  for (const action of actions) {
+    if (!byShortcut.has(action.shortcut)) byShortcut.set(action.shortcut, action);
+  }
+  return Array.from(byShortcut.values());
+}
+
+function backendConfig(config) {
+  return (
+    config.linuxShortcutBackend ?? {
+      backend: "linux-evdev-helper",
+      mode: "enabled",
+      elevation: "pkexec",
+      enableUinput: false,
+    }
+  );
+}
+
+function launchConfigFromSettings(config) {
+  const backend = backendConfig(config);
+  const actions = actionsFromConfig(config);
+  const actionAccelerators = new Set(actions.map((action) => action.shortcut));
+  const configuredHotkeys = backend.hotkeys?.length
+    ? backend.hotkeys.filter((hotkey) => actionAccelerators.has(hotkey.accelerator))
+    : actions.map((action) => ({
+        id: action.id,
+        accelerator: action.shortcut,
+        passthrough: true,
+      }));
+
+  const devices =
+    process.argv.includes("--all-devices")
+      ? discoverKeyboardEventDevices()
+      : splitList(process.env.EXILED_EXCHANGE_LINUX_HOTKEY_DEVICES).length > 0
+      ? splitList(process.env.EXILED_EXCHANGE_LINUX_HOTKEY_DEVICES)
+      : Array.from(
+          new Set([...(backend.devices ?? []), ...discoverKeyboardEventDevices()]),
+        ).sort();
+
+  if (!devices.length) throw new Error("no /dev/input/event* keyboard devices found");
+  for (const device of devices) {
+    if (!/^\/dev\/input\/event[0-9]+$/.test(device)) {
+      throw new Error(`invalid evdev path: ${device}`);
+    }
+  }
+  if (!configuredHotkeys.length) throw new Error("no settings hotkeys found for helper");
+
+  return {
+    backend: "linux-evdev-helper",
+    parentPid: process.pid,
+    devices,
+    enableUinput: false,
+    hotkeys: configuredHotkeys.map((hotkey) => ({
+      ...hotkey,
+      ...parseAccelerator(hotkey.accelerator),
+    })),
+  };
+}
+
+function spawnCommand(helperPath, elevation) {
+  const helperArgs = ["--replace-existing"];
+  if (process.argv.includes("--debug-events")) helperArgs.push("--debug-events");
+  if (elevation === "none") return { command: helperPath, args: helperArgs };
+  if (elevation === "sudo") return { command: "sudo", args: ["-A", helperPath, ...helperArgs] };
+  return { command: "pkexec", args: [helperPath, ...helperArgs] };
+}
+
+function formatEvent(event) {
+  if (event.type === "hotkey") {
+    return `HOTKEY id=${event.id} accelerator=${event.accelerator} ts=${event.ts}`;
+  }
+  if (event.type === "ready") {
+    return `READY devices=${event.devices.length} hotkeys=${event.hotkeys}`;
+  }
+  if (event.type === "error") {
+    return `ERROR code=${event.code} message=${event.message}${event.device ? ` device=${event.device}` : ""}`;
+  }
+  return JSON.stringify(event);
+}
+
+const configPath = path.resolve(argValue("--config") ?? process.env.EXILED_EXCHANGE_CONFIG ?? defaultConfigPath());
+const helperPath = path.resolve(argValue("--helper") ?? process.env.EXILED_EXCHANGE_LINUX_HOTKEY_HELPER ?? defaultHelperPath());
+const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+const backend = backendConfig(config);
+const launchConfig = launchConfigFromSettings(config);
+const command = spawnCommand(helperPath, backend.elevation ?? "pkexec");
+
+console.log(`Config: ${configPath}`);
+console.log(`Helper: ${helperPath}`);
+console.log(`Command: ${command.command} ${command.args.join(" ")}`);
+console.log(`Devices: ${launchConfig.devices.join(", ")}`);
+console.log(`Hotkeys: ${launchConfig.hotkeys.map((hotkey) => `${hotkey.id}=${hotkey.accelerator}`).join(", ")}`);
+
+const child = spawn(command.command, command.args, {
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+let stdoutBuffer = "";
+child.stdout.on("data", (chunk) => {
+  stdoutBuffer += chunk.toString("utf8");
+  for (;;) {
+    const index = stdoutBuffer.indexOf("\n");
+    if (index === -1) break;
+    const line = stdoutBuffer.slice(0, index).trim();
+    stdoutBuffer = stdoutBuffer.slice(index + 1);
+    if (!line) continue;
+    try {
+      console.log(formatEvent(JSON.parse(line)));
+    } catch (error) {
+      console.log(`INVALID ${line} (${error.message})`);
+    }
+  }
+});
+
+child.stderr.on("data", (chunk) => {
+  for (const line of chunk.toString("utf8").split(/\r?\n/)) {
+    if (line.trim()) console.error(`helper stderr: ${line.trim()}`);
+  }
+});
+
+child.on("error", (error) => {
+  console.error(`failed to launch helper: ${error.message}`);
+  process.exitCode = 1;
+});
+
+child.on("exit", (code, signal) => {
+  console.log(`Helper exited: ${signal ?? `code ${code ?? "unknown"}`}`);
+});
+
+child.stdin.end(`${JSON.stringify(launchConfig)}\n`);
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    child.kill("SIGTERM");
+    setTimeout(() => process.exit(signal === "SIGINT" ? 130 : 143), 250);
+  });
+}

--- a/main/src/AppTray.ts
+++ b/main/src/AppTray.ts
@@ -5,6 +5,7 @@ import type { ServerEvents } from "./server";
 export class AppTray {
   public overlayKey = "Shift + Space";
   private tray: Tray;
+  private openSettings?: () => void;
   serverPort = 0;
 
   constructor(server: ServerEvents) {
@@ -33,11 +34,24 @@ export class AppTray {
     });
   }
 
+  setOpenSettingsHandler(handler: () => void) {
+    this.openSettings = handler;
+    this.rebuildMenu();
+  }
+
   rebuildMenu() {
     const contextMenu = Menu.buildFromTemplate([
       {
         label: "Settings/League",
         click: () => {
+          if (
+            this.openSettings &&
+            (process.env.WAYLAND_DISPLAY || process.env.VITE_DEV_SERVER_URL)
+          ) {
+            this.openSettings();
+            return;
+          }
+
           dialog.showMessageBox({
             title: "Settings",
             message: `Open Path of Exile 2 and press "${this.overlayKey}". Click on the button with cog icon there.`,
@@ -47,7 +61,7 @@ export class AppTray {
       {
         label: "Open in Browser",
         click: () => {
-          shell.openExternal(`http://localhost:${this.serverPort}`);
+          shell.openExternal(`http://127.0.0.1:${this.serverPort}`);
         },
       },
       { type: "separator" },

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -2,8 +2,17 @@
 
 import { app, systemPreferences } from "electron";
 import { uIOhook } from "uiohook-napi";
+import fs from "node:fs";
 import os from "node:os";
-import { startServer, eventPipe, server } from "./server";
+import path from "node:path";
+import {
+  startServer,
+  eventPipe,
+  server,
+  setDebugOverlayCaptureProvider,
+  setDebugOverlayStateProvider,
+  setLinuxHotkeyHelperStatusProvider,
+} from "./server";
 import { Logger } from "./RemoteLogger";
 import { GameWindow } from "./windowing/GameWindow";
 import { OverlayWindow } from "./windowing/OverlayWindow";
@@ -24,7 +33,9 @@ if (!app.requestSingleInstanceLock()) {
 if (process.platform !== "darwin") {
   app.disableHardwareAcceleration();
 }
-app.enableSandbox();
+if (!process.env.VITE_DEV_SERVER_URL) {
+  app.enableSandbox();
+}
 let tray: AppTray;
 
 (async () => {
@@ -92,6 +103,11 @@ let tray: AppTray;
     setTimeout(
       async () => {
         const overlay = new OverlayWindow(eventPipe, logger, poeWindow);
+        setDebugOverlayCaptureProvider(() => overlay.captureDebugPng());
+        setDebugOverlayStateProvider(() => overlay.debugState());
+        tray.setOpenSettingsHandler(() => {
+          overlay.openSettings();
+        });
         // eslint-disable-next-line no-new
         new OverlayVisibility(eventPipe, overlay, gameConfig);
         const shortcuts = await Shortcuts.create(
@@ -101,9 +117,16 @@ let tray: AppTray;
           gameConfig,
           eventPipe,
         );
+        setLinuxHotkeyHelperStatusProvider(() => shortcuts.helperStatus);
         eventPipe.onEventAnyClient(
           "CLIENT->MAIN::update-host-config",
           (cfg) => {
+            cfg.linuxShortcutBackend ??= defaultWaylandShortcutBackend();
+            if (cfg.linuxShortcutBackend?.backend === "linux-evdev-helper") {
+              cfg.linuxShortcutBackend.devices = mergeDiscoveredInputDevices(
+                cfg.linuxShortcutBackend.devices,
+              );
+            }
             overlay.updateOpts(cfg.overlayKey, cfg.windowTitle);
             shortcuts.updateActions(
               cfg.shortcuts,
@@ -111,6 +134,7 @@ let tray: AppTray;
               cfg.logKeys,
               cfg.restoreClipboard,
               cfg.language,
+              cfg.linuxShortcutBackend,
             );
             shortcuts.updateDelay(cfg.initialDelay);
             gameLogWatcher.restart(cfg.clientLog ?? "", cfg.readClientLog);
@@ -133,3 +157,54 @@ let tray: AppTray;
     );
   });
 })();
+
+function defaultWaylandShortcutBackend() {
+  if (process.platform !== "linux" || !process.env.WAYLAND_DISPLAY) {
+    return undefined;
+  }
+
+  const devices = process.env.EXILED_EXCHANGE_LINUX_HOTKEY_DEVICES
+    ? process.env.EXILED_EXCHANGE_LINUX_HOTKEY_DEVICES.split(",")
+        .map((device) => device.trim())
+        .filter(Boolean)
+    : discoverKeyboardEventDevices();
+
+  return {
+    backend: "linux-evdev-helper" as const,
+    mode: "enabled" as const,
+    elevation: "pkexec" as const,
+    devices: mergeDiscoveredInputDevices(devices),
+    enableUinput: false as const,
+  };
+}
+
+function mergeDiscoveredInputDevices(configured: string[] | undefined) {
+  return Array.from(
+    new Set([...(configured ?? []), ...discoverKeyboardEventDevices()]),
+  ).sort();
+}
+
+function discoverKeyboardEventDevices() {
+  const devices = new Set<string>();
+  for (const dir of ["/dev/input/by-path", "/dev/input/by-id"]) {
+    try {
+      for (const entry of fs.readdirSync(dir)) {
+        if (!entry.endsWith("-event-kbd")) continue;
+        const device = fs.realpathSync(path.join(dir, entry));
+        if (/^\/dev\/input\/event[0-9]+$/.test(device)) {
+          devices.add(device);
+        }
+      }
+    } catch {}
+  }
+
+  try {
+    for (const entry of fs.readdirSync("/dev/input")) {
+      if (/^event[0-9]+$/.test(entry)) {
+        devices.add(path.join("/dev/input", entry));
+      }
+    }
+  } catch {}
+
+  return Array.from(devices).sort();
+}

--- a/main/src/server.ts
+++ b/main/src/server.ts
@@ -5,7 +5,12 @@ import { EventEmitter } from "events";
 import * as fs from "fs";
 import * as path from "path";
 import { app } from "electron";
-import { IpcEvent, IpcEventPayload, HostState } from "../../ipc/types";
+import {
+  IpcEvent,
+  IpcEventPayload,
+  HostState,
+  LinuxHotkeyHelperStatus,
+} from "../../ipc/types";
 import { ConfigStore } from "./host-files/ConfigStore";
 import { addFileUploadRoutes } from "./host-files/file-uploads";
 import type { AppUpdater } from "./AppUpdater";
@@ -14,6 +19,21 @@ import type { Logger } from "./RemoteLogger";
 export const server = createServer();
 const websocketServer = new WebSocketServer({ noServer: true });
 let lastActiveClient: WebSocket;
+let debugOverlayCaptureProvider:
+  | (() => Promise<Buffer | null>)
+  | undefined;
+let debugOverlayStateProvider:
+  | (() => Promise<unknown>)
+  | undefined;
+let linuxHotkeyHelperStatusProvider = (): LinuxHotkeyHelperStatus => ({
+  isWayland: Boolean(process.env.WAYLAND_DISPLAY),
+  configured: false,
+  running: false,
+  elevation: "pkexec",
+  command: null,
+  capturing: [],
+  error: null,
+});
 
 addFileUploadRoutes(server);
 
@@ -60,11 +80,11 @@ export function sendEventTo(
   event: IpcEvent,
 ) {
   const msg = JSON.stringify(event);
-  if (target === "broadcast") {
+  if (target === "broadcast" || target === "any") {
     for (const client of websocketServer.clients) {
       client.send(msg);
     }
-  } else {
+  } else if (lastActiveClient) {
     lastActiveClient.send(msg);
   }
 }
@@ -77,6 +97,22 @@ export const eventPipe = {
   onEventAnyClient,
   sendEventTo,
 };
+
+export function setLinuxHotkeyHelperStatusProvider(
+  provider: () => LinuxHotkeyHelperStatus,
+) {
+  linuxHotkeyHelperStatusProvider = provider;
+}
+
+export function setDebugOverlayCaptureProvider(
+  provider: () => Promise<Buffer | null>,
+) {
+  debugOverlayCaptureProvider = provider;
+}
+
+export function setDebugOverlayStateProvider(provider: () => Promise<unknown>) {
+  debugOverlayStateProvider = provider;
+}
 
 server.on("upgrade", (req, socket, head) => {
   if (req.url !== "/events") {
@@ -114,14 +150,38 @@ export async function startServer(
       name: "MAIN->CLIENT::log-entry",
       payload: { message: logger.history },
     });
+    sendEventTo("last-active", {
+      name: "MAIN->CLIENT::linux-hotkey-helper-state",
+      payload: linuxHotkeyHelperStatusProvider(),
+    });
   });
 
   server.addListener("request", async (req, res) => {
+    if (req.url === "/debug/overlay-screenshot" && process.env.VITE_DEV_SERVER_URL) {
+      const image = await debugOverlayCaptureProvider?.();
+      if (!image) {
+        res.statusCode = 404;
+        res.end("overlay window unavailable");
+        return;
+      }
+      res.setHeader("content-type", "image/png");
+      res.end(image);
+      return;
+    }
+
+    if (req.url === "/debug/overlay-state" && process.env.VITE_DEV_SERVER_URL) {
+      const state = await debugOverlayStateProvider?.();
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(state ?? null));
+      return;
+    }
+
     if (req.url === "/config") {
       res.setHeader("content-type", "application/json");
       const resBody: HostState = {
         version: app.getVersion(),
         updater: appUpdater.info,
+        linuxHotkeyHelper: linuxHotkeyHelperStatusProvider(),
         contents: await configStore.load(),
       };
       res.end(JSON.stringify(resBody));

--- a/main/src/shortcuts/Shortcuts.ts
+++ b/main/src/shortcuts/Shortcuts.ts
@@ -9,12 +9,22 @@ import { typeInChat, stashSearch } from "./text-box";
 import { WidgetAreaTracker } from "../windowing/WidgetAreaTracker";
 import { HostClipboard } from "./HostClipboard";
 import { OcrWorker } from "../vision/link-main";
-import type { ShortcutAction } from "../../../ipc/types";
+import type {
+  LinuxHotkeyHelperStatus,
+  LinuxShortcutBackendConfig,
+  LinuxHotkeyHelperDebugEvent,
+  ShortcutAction,
+} from "../../../ipc/types";
 import type { Logger } from "../RemoteLogger";
 import type { OverlayWindow } from "../windowing/OverlayWindow";
 import type { GameWindow } from "../windowing/GameWindow";
 import type { GameConfig } from "../host-files/GameConfig";
 import type { ServerEvents } from "../server";
+import { LinuxEvdevHelperProcess } from "./linux-evdev/helper-process";
+import { selectLinuxEvdevBackend } from "./linux-evdev/backend-selection";
+import { resolveHelperPath } from "./linux-evdev/helper-process";
+import { buildHelperSpawnCommand } from "./linux-evdev/launch-command";
+import type { HelperEvent, ShortcutActionWithId } from "./linux-evdev/types";
 
 type UiohookKeyT = keyof typeof UiohookKey;
 const UiohookToName = Object.fromEntries(
@@ -23,6 +33,9 @@ const UiohookToName = Object.fromEntries(
 
 export class Shortcuts {
   private actions: ShortcutAction[] = [];
+  private linuxShortcutBackend?: LinuxShortcutBackendConfig;
+  private linuxHelper?: LinuxEvdevHelperProcess;
+  private linuxHelperError: string | null = null;
   private stashScroll = false;
   private logKeys = false;
   private areaTracker: WidgetAreaTracker;
@@ -62,9 +75,11 @@ export class Shortcuts {
       process.nextTick(() => {
         if (isActive === this.poeWindow.isActive) {
           if (isActive) {
+            this.unregister();
             this.register();
           } else {
             this.unregister();
+            this.registerOverlayShortcut();
           }
         }
       });
@@ -73,6 +88,8 @@ export class Shortcuts {
     this.server.onEventAnyClient("CLIENT->MAIN::user-action", (e) => {
       if (e.action === "stash-search") {
         stashSearch(e.text, this.clipboard, this.overlay);
+      } else if (e.action === "restart-linux-hotkey-helper") {
+        this.restartLinuxHelper();
       }
     });
 
@@ -107,13 +124,48 @@ export class Shortcuts {
     this.clipboard.updateDelay(delay);
   }
 
+  get helperStatus(): LinuxHotkeyHelperStatus {
+    const isWayland = Boolean(process.env.WAYLAND_DISPLAY);
+    const configured =
+      process.platform === "linux" &&
+      this.linuxShortcutBackend?.backend === "linux-evdev-helper";
+    const elevation = this.linuxShortcutBackend?.elevation ?? "pkexec";
+    const command = configured ? this.helperCommandText(elevation) : null;
+
+    return {
+      isWayland,
+      configured,
+      running: Boolean(this.linuxHelper),
+      elevation,
+      command,
+      capturing: configured
+        ? this.actions.map((action) => action.shortcut)
+        : [],
+      error: this.linuxHelperError,
+    };
+  }
+
   updateActions(
     actions: ShortcutAction[],
     stashScroll: boolean,
     logKeys: boolean,
     restoreClipboard: boolean,
     language: string,
+    linuxShortcutBackend?: LinuxShortcutBackendConfig,
   ) {
+    const shouldRefreshActiveBackend = this.poeWindow.isActive;
+    if (shouldRefreshActiveBackend && this.linuxHelper) {
+      this.logger.write(
+        "info [linux-evdev-helper] Restarting helper because hotkeys changed.",
+      );
+    }
+
+    this.stopLinuxHelper();
+    if (shouldRefreshActiveBackend) {
+      this.unregister();
+    }
+
+    this.linuxShortcutBackend = linuxShortcutBackend;
     this.stashScroll = stashScroll;
     this.logKeys = logKeys;
     this.clipboard.updateOptions(restoreClipboard);
@@ -173,107 +225,51 @@ export class Shortcuts {
         !duplicates.has(action.shortcut) ||
         action.action.type === "toggle-overlay",
     );
+
+    if (this.shouldRunLinuxHelper()) {
+      this.startLinuxHelper("wayland");
+    } else if (shouldRefreshActiveBackend) {
+      this.register();
+    } else {
+      this.registerOverlayShortcut();
+    }
   }
 
   private register() {
+    if (this.linuxHelper) return;
+
+    const selection = selectLinuxEvdevBackend(
+      process.platform,
+      this.linuxShortcutBackend,
+      0,
+    );
+    if (selection.useHelper) {
+      this.startLinuxHelper("explicit");
+      return;
+    }
+
+    const failed = this.registerElectronShortcuts();
+    const fallbackSelection = selectLinuxEvdevBackend(
+      process.platform,
+      this.linuxShortcutBackend,
+      failed,
+    );
+    if (fallbackSelection.useHelper) {
+      globalShortcut.unregisterAll();
+      this.startLinuxHelper("register-failed");
+    }
+  }
+
+  private registerElectronShortcuts() {
+    let failed = 0;
     for (const entry of this.actions) {
       const isOk = globalShortcut.register(
         shortcutToElectron(entry.shortcut),
-        () => {
-          if (this.logKeys) {
-            this.logger.write(
-              `debug [Shortcuts] Action type: ${entry.action.type}`,
-            );
-          }
-
-          if (entry.keepModKeys) {
-            const nonModKey = entry.shortcut
-              .split(" + ")
-              .filter((key) => !isModKey(key))[0];
-            uIOhook.keyToggle(UiohookKey[nonModKey as UiohookKeyT], "up");
-          } else {
-            entry.shortcut
-              .split(" + ")
-              .reverse()
-              .forEach((key) => {
-                uIOhook.keyToggle(UiohookKey[key as UiohookKeyT], "up");
-              });
-          }
-
-          if (entry.action.type === "toggle-overlay") {
-            this.areaTracker.removeListeners();
-            this.overlay.toggleActiveState();
-          } else if (entry.action.type === "paste-in-chat") {
-            typeInChat(entry.action.text, entry.action.send, this.clipboard);
-          } else if (entry.action.type === "trigger-event") {
-            this.server.sendEventTo("broadcast", {
-              name: "MAIN->CLIENT::widget-action",
-              payload: { target: entry.action.target },
-            });
-          } else if (entry.action.type === "stash-search") {
-            stashSearch(entry.action.text, this.clipboard, this.overlay);
-          } else if (entry.action.type === "copy-item") {
-            const { action } = entry;
-
-            const pressPosition = screen.getCursorScreenPoint();
-
-            this.clipboard
-              .readItemText()
-              .then((clipboard) => {
-                this.areaTracker.removeListeners();
-                this.server.sendEventTo("last-active", {
-                  name: "MAIN->CLIENT::item-text",
-                  payload: {
-                    target: action.target,
-                    clipboard,
-                    position: pressPosition,
-                    focusOverlay: Boolean(action.focusOverlay),
-                  },
-                });
-                if (action.focusOverlay && this.overlay.wasUsedRecently) {
-                  this.overlay.assertOverlayActive();
-                }
-              })
-              .catch(() => {});
-
-            pressKeysToCopyItemText(
-              entry.keepModKeys
-                ? entry.shortcut.split(" + ").filter((key) => isModKey(key))
-                : undefined,
-              this.gameConfig.showModsKey,
-            );
-          } else if (
-            entry.action.type === "ocr-text" &&
-            entry.action.target === "heist-gems"
-          ) {
-            if (process.platform !== "win32") return;
-
-            const { action } = entry;
-            const pressTime = Date.now();
-            const imageData = this.poeWindow.screenshot();
-            this.ocrWorker
-              .findHeistGems({
-                width: this.poeWindow.bounds.width,
-                height: this.poeWindow.bounds.height,
-                data: imageData,
-              })
-              .then((result) => {
-                this.server.sendEventTo("last-active", {
-                  name: "MAIN->CLIENT::ocr-text",
-                  payload: {
-                    target: action.target,
-                    pressTime,
-                    ocrTime: result.elapsed,
-                    paragraphs: result.recognized.map((p) => p.text),
-                  },
-                });
-              })
-              .catch(() => {});
-          }
-        },
+        () => this.runAction(entry),
       );
 
       if (!isOk) {
+        failed += 1;
         this.logger.write(
           `error [Shortcuts] Failed to register a shortcut "${entry.shortcut}". It is already registered by another application.`,
         );
@@ -283,10 +279,288 @@ export class Shortcuts {
         globalShortcut.unregister(shortcutToElectron(entry.shortcut));
       }
     }
+
+    return failed;
+  }
+
+  private registerOverlayShortcut() {
+    const entry = this.actions.find(
+      (entry) => entry.action.type === "toggle-overlay",
+    );
+    if (!entry) return;
+
+    const isOk = globalShortcut.register(
+      shortcutToElectron(entry.shortcut),
+      () => this.runAction(entry),
+    );
+    if (!isOk) {
+      this.logger.write(
+        `error [Shortcuts] Failed to register overlay shortcut "${entry.shortcut}". It is already registered by another application.`,
+      );
+    }
   }
 
   private unregister() {
+    if (!this.shouldRunLinuxHelper()) {
+      this.stopLinuxHelper();
+    }
     globalShortcut.unregisterAll();
+  }
+
+  private startLinuxHelper(reason: string) {
+    if (!this.linuxShortcutBackend) return;
+    this.stopLinuxHelper();
+
+    const actions = this.actionsWithIds();
+    const byId = new Map(actions.map(({ id, entry }) => [id, entry]));
+    this.linuxHelper = new LinuxEvdevHelperProcess(
+      this.logger,
+      this.linuxShortcutBackend,
+      actions,
+    );
+    this.emitHelperDebugEvent({
+      kind: "start",
+      message: `starting helper via ${reason}`,
+    });
+    this.linuxHelper.on("message", (message: HelperEvent) => {
+      if (message.type === "ready") {
+        this.emitHelperDebugEvent({
+          kind: "ready",
+          message: `ready; devices=${message.devices.length}, hotkeys=${message.hotkeys}`,
+        });
+        this.linuxHelperError = null;
+        this.logger.write(
+          `info [linux-evdev-helper] ready via ${reason}; devices=${message.devices.length}, hotkeys=${message.hotkeys}`,
+        );
+        this.emitHelperStatus();
+      } else if (message.type === "hotkey") {
+        this.emitHelperDebugEvent({
+          kind: "hotkey",
+          id: message.id,
+          accelerator: message.accelerator,
+          helperTs: message.ts,
+          message: `received ${message.accelerator}`,
+        });
+        const entry = byId.get(message.id);
+        if (!entry) {
+          this.logger.write(
+            `warn [linux-evdev-helper] Ignoring unknown hotkey id "${message.id}"`,
+          );
+          return;
+        }
+        if (
+          !this.poeWindow.isActive &&
+          entry.action.type !== "toggle-overlay"
+        ) {
+          return;
+        }
+        this.runAction(entry);
+      } else if (message.type === "error") {
+        this.emitHelperDebugEvent({
+          kind: "error",
+          code: message.code,
+          device: message.device,
+          message: message.message,
+        });
+      }
+    });
+    this.linuxHelper.on("error-event", (error: Error) => {
+      this.emitHelperDebugEvent({
+        kind: "error",
+        message: error.message,
+      });
+      this.linuxHelperError = "helper process failed to start";
+      this.stopLinuxHelper();
+      if (this.poeWindow.isActive) {
+        this.registerElectronShortcuts();
+      }
+      this.emitHelperStatus();
+    });
+    this.linuxHelper.on(
+      "exit",
+      (code: number | null, signal: string | null) => {
+        this.emitHelperDebugEvent({
+          kind: "exit",
+          exitCode: code,
+          signal,
+          message: `helper exited with ${signal ?? `code ${code ?? "unknown"}`}`,
+        });
+        this.linuxHelper = undefined;
+        this.emitHelperStatus();
+        if (!this.shouldRunLinuxHelper() && this.poeWindow.isActive) {
+          this.registerElectronShortcuts();
+        }
+      },
+    );
+
+    try {
+      this.linuxHelper.start();
+    } catch (error) {
+      this.linuxHelperError = (error as Error).message;
+      this.logger.write(`error [linux-evdev-helper] ${this.linuxHelperError}`);
+      this.stopLinuxHelper();
+      if (!this.shouldRunLinuxHelper() && this.poeWindow.isActive) {
+        this.registerElectronShortcuts();
+      }
+      this.emitHelperStatus();
+    }
+    this.emitHelperStatus();
+  }
+
+  private stopLinuxHelper() {
+    this.linuxHelper?.removeAllListeners();
+    this.linuxHelper?.stop();
+    this.linuxHelper = undefined;
+  }
+
+  private actionsWithIds(): ShortcutActionWithId[] {
+    const configured = this.linuxShortcutBackend?.hotkeys ?? [];
+    return this.actions.map((entry, index) => ({
+      id:
+        configured.find((hotkey) => hotkey.accelerator === entry.shortcut)
+          ?.id ?? `shortcut-${index}`,
+      entry,
+    }));
+  }
+
+  private restartLinuxHelper() {
+    if (!this.shouldRunLinuxHelper()) {
+      this.emitHelperStatus();
+      return;
+    }
+    this.logger.write(
+      "info [linux-evdev-helper] Restart requested from settings.",
+    );
+    this.startLinuxHelper("manual-restart");
+  }
+
+  private shouldRunLinuxHelper() {
+    return (
+      process.platform === "linux" &&
+      Boolean(process.env.WAYLAND_DISPLAY) &&
+      this.linuxShortcutBackend?.backend === "linux-evdev-helper"
+    );
+  }
+
+  private helperCommandText(
+    elevation: LinuxShortcutBackendConfig["elevation"] = "pkexec",
+  ) {
+    try {
+      const helperPath = resolveHelperPath(
+        this.linuxShortcutBackend?.helperPath,
+      );
+      const command = buildHelperSpawnCommand(helperPath, elevation);
+      return [command.command, ...command.args].join(" ");
+    } catch (error) {
+      return `error: ${(error as Error).message}`;
+    }
+  }
+
+  private emitHelperStatus() {
+    this.server.sendEventTo("broadcast", {
+      name: "MAIN->CLIENT::linux-hotkey-helper-state",
+      payload: this.helperStatus,
+    });
+  }
+
+  private emitHelperDebugEvent(event: Omit<LinuxHotkeyHelperDebugEvent, "at">) {
+    this.server.sendEventTo("broadcast", {
+      name: "MAIN->CLIENT::linux-hotkey-helper-debug-event",
+      payload: {
+        at: Date.now(),
+        ...event,
+      },
+    });
+  }
+
+  private runAction(entry: ShortcutAction) {
+    if (this.logKeys) {
+      this.logger.write(`debug [Shortcuts] Action type: ${entry.action.type}`);
+    }
+
+    if (entry.keepModKeys) {
+      const nonModKey = entry.shortcut
+        .split(" + ")
+        .filter((key) => !isModKey(key))[0];
+      uIOhook.keyToggle(UiohookKey[nonModKey as UiohookKeyT], "up");
+    } else {
+      entry.shortcut
+        .split(" + ")
+        .reverse()
+        .forEach((key) => {
+          uIOhook.keyToggle(UiohookKey[key as UiohookKeyT], "up");
+        });
+    }
+
+    if (entry.action.type === "toggle-overlay") {
+      this.areaTracker.removeListeners();
+      this.overlay.toggleActiveState();
+    } else if (entry.action.type === "paste-in-chat") {
+      typeInChat(entry.action.text, entry.action.send, this.clipboard);
+    } else if (entry.action.type === "trigger-event") {
+      this.server.sendEventTo("broadcast", {
+        name: "MAIN->CLIENT::widget-action",
+        payload: { target: entry.action.target },
+      });
+    } else if (entry.action.type === "stash-search") {
+      stashSearch(entry.action.text, this.clipboard, this.overlay);
+    } else if (entry.action.type === "copy-item") {
+      const { action } = entry;
+      const pressPosition = screen.getCursorScreenPoint();
+
+      this.clipboard
+        .readItemText()
+        .then((clipboard) => {
+          this.areaTracker.removeListeners();
+          this.server.sendEventTo("last-active", {
+            name: "MAIN->CLIENT::item-text",
+            payload: {
+              target: action.target,
+              clipboard,
+              position: pressPosition,
+              focusOverlay: Boolean(action.focusOverlay),
+            },
+          });
+          if (action.focusOverlay && this.overlay.wasUsedRecently) {
+            this.overlay.assertOverlayActive();
+          }
+        })
+        .catch(() => {});
+
+      pressKeysToCopyItemText(
+        entry.keepModKeys
+          ? entry.shortcut.split(" + ").filter((key) => isModKey(key))
+          : undefined,
+        this.gameConfig.showModsKey,
+      );
+    } else if (
+      entry.action.type === "ocr-text" &&
+      entry.action.target === "heist-gems"
+    ) {
+      if (process.platform !== "win32") return;
+
+      const { action } = entry;
+      const pressTime = Date.now();
+      const imageData = this.poeWindow.screenshot();
+      this.ocrWorker
+        .findHeistGems({
+          width: this.poeWindow.bounds.width,
+          height: this.poeWindow.bounds.height,
+          data: imageData,
+        })
+        .then((result) => {
+          this.server.sendEventTo("last-active", {
+            name: "MAIN->CLIENT::ocr-text",
+            payload: {
+              target: action.target,
+              pressTime,
+              ocrTime: result.elapsed,
+              paragraphs: result.recognized.map((p) => p.text),
+            },
+          });
+        })
+        .catch(() => {});
+    }
   }
 }
 

--- a/main/src/shortcuts/linux-evdev/accelerator.ts
+++ b/main/src/shortcuts/linux-evdev/accelerator.ts
@@ -1,0 +1,140 @@
+import { isModKey } from "../../../../ipc/KeyToCode";
+
+export interface ParsedAccelerator {
+  accelerator: string;
+  key: string;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  meta: boolean;
+}
+
+const KEY_ALIASES: Record<string, string> = {
+  CONTROL: "Ctrl",
+  CTRL: "Ctrl",
+  COMMAND: "Meta",
+  CMD: "Meta",
+  SUPER: "Meta",
+  META: "Meta",
+  OPTION: "Alt",
+  ALT: "Alt",
+  SHIFT: "Shift",
+  SPACE: "Space",
+  ESC: "Escape",
+  ESCAPE: "Escape",
+  RETURN: "Enter",
+  ENTER: "Enter",
+  DELETE: "Delete",
+  DEL: "Delete",
+  BACKSPACE: "Backspace",
+  TAB: "Tab",
+  HOME: "Home",
+  END: "End",
+  PAGEUP: "PageUp",
+  PAGEDOWN: "PageDown",
+  LEFT: "ArrowLeft",
+  RIGHT: "ArrowRight",
+  UP: "ArrowUp",
+  DOWN: "ArrowDown",
+};
+
+const VALID_NAMED_KEYS = new Set([
+  "Backspace",
+  "Tab",
+  "Enter",
+  "CapsLock",
+  "Escape",
+  "Space",
+  "PageUp",
+  "PageDown",
+  "End",
+  "Home",
+  "ArrowLeft",
+  "ArrowUp",
+  "ArrowRight",
+  "ArrowDown",
+  "Insert",
+  "Delete",
+  "Semicolon",
+  "Equal",
+  "Comma",
+  "Minus",
+  "Period",
+  "Slash",
+  "Backquote",
+  "BracketLeft",
+  "Backslash",
+  "BracketRight",
+  "Quote",
+]);
+
+export function parseAccelerator(accelerator: string): ParsedAccelerator {
+  const parts = accelerator
+    .split(/\s*\+\s*/)
+    .map((part) => normalizeKey(part))
+    .filter((part) => part.length > 0);
+
+  if (!parts.length) {
+    throw new Error("Accelerator is empty");
+  }
+
+  let ctrl = false;
+  let shift = false;
+  let alt = false;
+  let meta = false;
+  const keys: string[] = [];
+
+  for (const part of parts) {
+    if (part === "Ctrl") ctrl = true;
+    else if (part === "Shift") shift = true;
+    else if (part === "Alt") alt = true;
+    else if (part === "Meta") meta = true;
+    else keys.push(part);
+  }
+
+  if (keys.length !== 1) {
+    throw new Error(`Accelerator must contain one non-modifier key: ${accelerator}`);
+  }
+
+  const key = keys[0];
+  if (isModKey(key) || key === "Meta") {
+    throw new Error(`Accelerator must not use only modifiers: ${accelerator}`);
+  }
+
+  return {
+    accelerator: acceleratorFromParts({ key, ctrl, shift, alt, meta }),
+    key,
+    ctrl,
+    shift,
+    alt,
+    meta,
+  };
+}
+
+export function acceleratorFromParts(accel: Omit<ParsedAccelerator, "accelerator">) {
+  return [
+    accel.ctrl ? "Ctrl" : null,
+    accel.shift ? "Shift" : null,
+    accel.alt ? "Alt" : null,
+    accel.meta ? "Meta" : null,
+    accel.key,
+  ]
+    .filter(Boolean)
+    .join(" + ");
+}
+
+function normalizeKey(key: string): string {
+  const upper = key.trim().toUpperCase();
+  if (!upper) return "";
+  if (KEY_ALIASES[upper]) return KEY_ALIASES[upper];
+  if (/^[A-Z0-9]$/.test(upper)) return upper;
+  if (/^F([1-9]|1[0-9]|2[0-4])$/.test(upper)) return upper;
+  if (/^NUMPAD[0-9]$/.test(upper)) return `Numpad${upper.slice("NUMPAD".length)}`;
+  if (VALID_NAMED_KEYS.has(key)) return key;
+
+  const pascal = upper[0] + upper.slice(1).toLowerCase();
+  if (VALID_NAMED_KEYS.has(pascal)) return pascal;
+
+  throw new Error(`Unsupported accelerator key: ${key}`);
+}
+

--- a/main/src/shortcuts/linux-evdev/backend-selection.ts
+++ b/main/src/shortcuts/linux-evdev/backend-selection.ts
@@ -1,0 +1,31 @@
+import type {
+  LinuxEvdevBackendSelection,
+  LinuxEvdevHelperConfig,
+} from "./types";
+
+export function selectLinuxEvdevBackend(
+  platform: NodeJS.Platform,
+  config: LinuxEvdevHelperConfig | undefined,
+  failedElectronRegistrations: number,
+): LinuxEvdevBackendSelection {
+  if (platform !== "linux") {
+    return { useHelper: false, reason: "unsupported-platform" };
+  }
+
+  if (!config || config.backend !== "linux-evdev-helper") {
+    return { useHelper: false, reason: "disabled" };
+  }
+
+  if (
+    config.mode !== "fallback" &&
+    process.env.EXILED_EXCHANGE_LINUX_HOTKEYS !== "fallback"
+  ) {
+    return { useHelper: true, reason: "explicit" };
+  }
+
+  if (failedElectronRegistrations > 0) {
+    return { useHelper: true, reason: "register-failed" };
+  }
+
+  return { useHelper: false, reason: "disabled" };
+}

--- a/main/src/shortcuts/linux-evdev/config.ts
+++ b/main/src/shortcuts/linux-evdev/config.ts
@@ -1,0 +1,59 @@
+import { parseAccelerator } from "./accelerator";
+import type {
+  LinuxEvdevHelperConfig,
+  LinuxEvdevHelperLaunchConfig,
+  ShortcutActionWithId,
+} from "./types";
+
+export function buildLaunchConfig(
+  config: LinuxEvdevHelperConfig,
+  actions: ShortcutActionWithId[],
+  devicesFromEnv = process.env.EXILED_EXCHANGE_LINUX_HOTKEY_DEVICES,
+): LinuxEvdevHelperLaunchConfig {
+  if (config.enableUinput) {
+    throw new Error("linux-evdev-helper uinput support is not implemented yet");
+  }
+
+  const devices = config.devices ?? parseListEnv(devicesFromEnv);
+  if (!devices.length) {
+    throw new Error("linux-evdev-helper requires at least one input device");
+  }
+  for (const device of devices) {
+    if (!/^\/dev\/input\/event[0-9]+$/.test(device)) {
+      throw new Error(`linux-evdev-helper device must be /dev/input/event*: ${device}`);
+    }
+  }
+
+  const actionAccelerators = new Set(actions.map(({ entry }) => entry.shortcut));
+  const configuredHotkeys = config.hotkeys?.length
+    ? config.hotkeys.filter((hotkey) => actionAccelerators.has(hotkey.accelerator))
+    : actions.map(({ id, entry }) => ({
+        id,
+        accelerator: entry.shortcut,
+        passthrough: true,
+      }));
+
+  if (!configuredHotkeys.length) {
+    throw new Error("linux-evdev-helper has no matching app hotkeys to register");
+  }
+
+  return {
+    backend: "linux-evdev-helper",
+    parentPid: process.pid,
+    devices,
+    enableUinput: false,
+    hotkeys: configuredHotkeys.map((hotkey) => ({
+      ...hotkey,
+      ...parseAccelerator(hotkey.accelerator),
+    })),
+  };
+}
+
+function parseListEnv(value: string | undefined): string[] {
+  return value
+    ? value
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean)
+    : [];
+}

--- a/main/src/shortcuts/linux-evdev/helper-process.ts
+++ b/main/src/shortcuts/linux-evdev/helper-process.ts
@@ -1,0 +1,120 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { EventEmitter } from "node:events";
+import { app } from "electron";
+import { buildLaunchConfig } from "./config";
+import { buildHelperSpawnCommand } from "./launch-command";
+import { NdjsonParser } from "./ndjson";
+import type { Logger } from "../../RemoteLogger";
+import type {
+  HelperEvent,
+  LinuxEvdevHelperConfig,
+  ShortcutActionWithId,
+} from "./types";
+
+export class LinuxEvdevHelperProcess extends EventEmitter {
+  private child?: ChildProcessWithoutNullStreams;
+  private parser = new NdjsonParser<HelperEvent>(
+    (message) => this.handleMessage(message),
+    (line, error) => {
+      this.logger.write(
+        `warn [linux-evdev-helper] Ignoring invalid helper output: ${error.message}: ${line}`,
+      );
+    },
+  );
+
+  constructor(
+    private logger: Logger,
+    private config: LinuxEvdevHelperConfig,
+    private actions: ShortcutActionWithId[],
+  ) {
+    super();
+  }
+
+  start() {
+    if (process.platform !== "linux") {
+      throw new Error("linux-evdev-helper is only available on Linux");
+    }
+
+    const launchConfig = buildLaunchConfig(this.config, this.actions);
+    const helperPath = resolveHelperPath(this.config.helperPath);
+    const spawnCommand = buildHelperSpawnCommand(
+      helperPath,
+      this.config.elevation ?? "pkexec",
+    );
+
+    this.child = spawn(spawnCommand.command, spawnCommand.args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+
+    this.child.stdout.on("data", (chunk) => this.parser.push(chunk));
+    this.child.stderr.on("data", (chunk) => {
+      for (const line of chunk.toString().split(/\r?\n/)) {
+        if (line.trim()) {
+          this.logger.write(`warn [linux-evdev-helper] ${line.trim()}`);
+        }
+      }
+    });
+    this.child.on("error", (error) => {
+      this.logger.write(`error [linux-evdev-helper] ${error.message}`);
+      this.emit("error-event", error);
+    });
+    this.child.on("exit", (code, signal) => {
+      this.parser.flush();
+      this.child = undefined;
+      if (code !== 0 && signal == null) {
+        this.logger.write(
+          `error [linux-evdev-helper] exited with code ${code ?? "unknown"}`,
+        );
+      }
+      this.emit("exit", code, signal);
+    });
+
+    this.child.stdin.end(`${JSON.stringify(launchConfig)}\n`);
+  }
+
+  stop() {
+    const child = this.child;
+    this.child = undefined;
+    if (!child || child.killed) return;
+    child.kill("SIGTERM");
+  }
+
+  private handleMessage(message: HelperEvent) {
+    if (message.type === "error") {
+      this.logger.write(
+        `error [linux-evdev-helper] ${message.code}: ${message.message}${
+          message.device ? ` (${message.device})` : ""
+        }`,
+      );
+    }
+    this.emit("message", message);
+  }
+}
+
+export function resolveHelperPath(helperPath?: string) {
+  const configured = helperPath ?? process.env.EXILED_EXCHANGE_LINUX_HOTKEY_HELPER;
+  if (configured) {
+    if (!path.isAbsolute(configured)) {
+      throw new Error("linux-evdev-helper helperPath must be absolute");
+    }
+    return configured;
+  }
+
+  if (app.isPackaged) {
+    return path.join(process.resourcesPath, "app.asar.unpacked", "linux-evdev-helper");
+  }
+
+  const sourceHelper = path.resolve(
+    process.cwd(),
+    "../native/linux-evdev-helper/linux-evdev-helper",
+  );
+  if (fs.existsSync(sourceHelper)) return sourceHelper;
+
+  const distHelper = path.resolve(process.cwd(), "dist/linux-evdev-helper");
+  if (fs.existsSync(distHelper)) return distHelper;
+
+  return sourceHelper;
+}

--- a/main/src/shortcuts/linux-evdev/launch-command.ts
+++ b/main/src/shortcuts/linux-evdev/launch-command.ts
@@ -1,0 +1,16 @@
+import type { LinuxEvdevHelperConfig } from "./types";
+
+export function buildHelperSpawnCommand(
+  helperPath: string,
+  elevation: LinuxEvdevHelperConfig["elevation"],
+) {
+  if (elevation === "none") {
+    return { command: helperPath, args: ["--replace-existing"] };
+  }
+
+  if (elevation === "sudo") {
+    return { command: "sudo", args: ["-A", helperPath, "--replace-existing"] };
+  }
+
+  return { command: "pkexec", args: [helperPath, "--replace-existing"] };
+}

--- a/main/src/shortcuts/linux-evdev/ndjson.ts
+++ b/main/src/shortcuts/linux-evdev/ndjson.ts
@@ -1,0 +1,39 @@
+export class NdjsonParser<T> {
+  private buffer = "";
+
+  constructor(
+    private onMessage: (message: T) => void,
+    private onInvalidLine: (line: string, error: Error) => void,
+  ) {}
+
+  push(chunk: string | Buffer) {
+    this.buffer += chunk.toString();
+    for (;;) {
+      const newline = this.buffer.indexOf("\n");
+      if (newline === -1) return;
+
+      const line = this.buffer.slice(0, newline).trim();
+      this.buffer = this.buffer.slice(newline + 1);
+      if (!line) continue;
+
+      try {
+        this.onMessage(JSON.parse(line) as T);
+      } catch (error) {
+        this.onInvalidLine(line, error as Error);
+      }
+    }
+  }
+
+  flush() {
+    const line = this.buffer.trim();
+    this.buffer = "";
+    if (!line) return;
+
+    try {
+      this.onMessage(JSON.parse(line) as T);
+    } catch (error) {
+      this.onInvalidLine(line, error as Error);
+    }
+  }
+}
+

--- a/main/src/shortcuts/linux-evdev/types.ts
+++ b/main/src/shortcuts/linux-evdev/types.ts
@@ -1,0 +1,55 @@
+import type { ShortcutAction } from "../../../../ipc/types";
+import type { ParsedAccelerator } from "./accelerator";
+
+export interface LinuxEvdevHotkeyConfig {
+  id: string;
+  accelerator: string;
+  passthrough?: boolean;
+}
+
+export interface LinuxEvdevHelperConfig {
+  backend: "linux-evdev-helper";
+  mode?: "enabled" | "fallback";
+  elevation?: "pkexec" | "sudo" | "none";
+  helperPath?: string;
+  devices?: string[];
+  hotkeys?: LinuxEvdevHotkeyConfig[];
+  enableUinput?: false;
+}
+
+export interface LinuxEvdevHelperLaunchConfig {
+  backend: "linux-evdev-helper";
+  parentPid: number;
+  devices: string[];
+  hotkeys: Array<LinuxEvdevHotkeyConfig & ParsedAccelerator>;
+  enableUinput: false;
+}
+
+export interface LinuxEvdevBackendSelection {
+  useHelper: boolean;
+  reason: "disabled" | "explicit" | "register-failed" | "unsupported-platform";
+}
+
+export type HelperEvent =
+  | {
+      type: "ready";
+      devices: string[];
+      hotkeys: number;
+    }
+  | {
+      type: "hotkey";
+      id: string;
+      accelerator: string;
+      ts: number;
+    }
+  | {
+      type: "error";
+      code: string;
+      message: string;
+      device?: string;
+    };
+
+export interface ShortcutActionWithId {
+  id: string;
+  entry: ShortcutAction;
+}

--- a/main/src/windowing/OverlayWindow.ts
+++ b/main/src/windowing/OverlayWindow.ts
@@ -1,5 +1,12 @@
 import path from "path";
-import { BrowserWindow, dialog, shell, Menu } from "electron";
+import {
+  BrowserWindow,
+  dialog,
+  shell,
+  Menu,
+  screen,
+  type Rectangle,
+} from "electron";
 import {
   OverlayController,
   OVERLAY_WINDOW_OPTS,
@@ -14,6 +21,11 @@ export class OverlayWindow {
   private window?: BrowserWindow;
   private overlayKey: string = "Shift + Space";
   private isOverlayKeyUsed = false;
+  private pendingSettingsOpen = false;
+  private didAutoOpenSettings = false;
+  private bypassGameWindow =
+    process.env.VITE_DEV_SERVER_URL != null ||
+    process.env.EXILED_EXCHANGE_BYPASS_POE_WINDOW === "1";
 
   constructor(
     private server: ServerEvents,
@@ -35,12 +47,24 @@ export class OverlayWindow {
 
     this.window = new BrowserWindow({
       icon: path.join(__dirname, process.env.STATIC!, "icon.png"),
-      ...OVERLAY_WINDOW_OPTS,
+      ...(this.bypassGameWindow
+        ? {
+            frame: false,
+            show: false,
+            transparent: true,
+            resizable: false,
+            fullscreenable: true,
+            skipTaskbar: true,
+            hasShadow: false,
+            backgroundColor: "#00000000",
+          }
+        : OVERLAY_WINDOW_OPTS),
       width: 800,
       height: 600,
       webPreferences: {
         allowRunningInsecureContent: false,
-        webviewTag: true,
+        sandbox: !this.bypassGameWindow,
+        webviewTag: !this.bypassGameWindow,
         spellcheck: false,
       },
     });
@@ -55,6 +79,22 @@ export class OverlayWindow {
 
     this.window.webContents.on("before-input-event", this.handleExtraCommands);
     this.window.webContents.on(
+      "console-message",
+      (_event, level, message, line, sourceId) => {
+        this.logger.write(
+          `debug [OverlayRenderer] console(${level}) ${message} (${sourceId}:${line})`,
+        );
+      },
+    );
+    this.window.webContents.on(
+      "did-fail-load",
+      (_event, errorCode, errorDescription, validatedURL) => {
+        this.logger.write(
+          `error [OverlayRenderer] Failed to load ${validatedURL}: ${errorCode} ${errorDescription}`,
+        );
+      },
+    );
+    this.window.webContents.on(
       "did-attach-webview",
       (_, webviewWebContents) => {
         webviewWebContents.on("before-input-event", this.handleExtraCommands);
@@ -65,11 +105,24 @@ export class OverlayWindow {
       shell.openExternal(details.url);
       return { action: "deny" };
     });
+
+    if (this.bypassGameWindow) {
+      this.fillMouseDisplay();
+    }
+
+    this.window.webContents.on("did-finish-load", () => {
+      if (this.pendingSettingsOpen) {
+        this.emitOpenSettings();
+      } else if (this.bypassGameWindow && !this.didAutoOpenSettings) {
+        this.didAutoOpenSettings = true;
+        this.openSettings();
+      }
+    });
   }
 
   loadAppPage(port: number) {
     const url =
-      process.env.VITE_DEV_SERVER_URL || `http://localhost:${port}/index.html`;
+      process.env.VITE_DEV_SERVER_URL || `http://127.0.0.1:${port}/index.html`;
 
     if (!this.window) {
       shell.openExternal(url);
@@ -84,7 +137,80 @@ export class OverlayWindow {
     }
   }
 
+  async captureDebugPng() {
+    if (!this.window || !process.env.VITE_DEV_SERVER_URL) return null;
+    const image = await this.window.webContents.capturePage();
+    return image.toPNG();
+  }
+
+  async debugState() {
+    if (!this.window || !process.env.VITE_DEV_SERVER_URL) return null;
+    let documentState: unknown = null;
+    try {
+      documentState = await this.window.webContents.executeJavaScript(
+        `(async () => {
+          let mainTs = null;
+          try {
+            const res = await fetch('/src/main.ts');
+            mainTs = {
+              ok: res.ok,
+              status: res.status,
+              contentType: res.headers.get('content-type'),
+              textStart: (await res.text()).slice(0, 500)
+            };
+          } catch (error) {
+            mainTs = { error: String(error) };
+          }
+          return {
+          href: location.href,
+          readyState: document.readyState,
+          bodyText: document.body?.innerText?.slice(0, 2000) ?? null,
+          bodyHtml: document.body?.innerHTML?.slice(0, 2000) ?? null,
+          linuxHotkeyHelperEventLog:
+            document.getElementById('linux-hotkey-helper-event-log')?.value ?? null,
+          boot: window.__EE2_BOOT ?? null,
+          scripts: Array.from(document.scripts).map((script) => ({
+            src: script.src,
+            type: script.type
+          })),
+          resources: performance.getEntriesByType('resource').map((entry) => entry.name).slice(0, 50),
+          mainTs
+        }})()`,
+      );
+    } catch (error) {
+      documentState = { error: (error as Error).message };
+    }
+
+    return {
+      url: this.window.webContents.getURL(),
+      title: this.window.webContents.getTitle(),
+      isLoading: this.window.webContents.isLoading(),
+      isVisible: this.window.isVisible(),
+      bounds: this.window.getBounds(),
+      documentState,
+    };
+  }
+
   assertOverlayActive = () => {
+    if (this.bypassGameWindow && this.window) {
+      this.isInteractable = true;
+      this.fillMouseDisplay();
+      this.window.setSkipTaskbar(true);
+      if (this.window.isMinimized()) {
+        this.window.restore();
+      }
+      this.window.show();
+      this.window.maximize();
+      this.window.moveTop();
+      this.window.focus();
+      this.poeWindow.isActive = false;
+      this.emitFocusState();
+      if (this.didAutoOpenSettings) {
+        this.emitOpenSettings();
+      }
+      return;
+    }
+
     if (!this.isInteractable) {
       this.isInteractable = true;
       OverlayController.activateOverlay();
@@ -92,9 +218,35 @@ export class OverlayWindow {
     }
   };
 
+  openSettings = () => {
+    this.pendingSettingsOpen = true;
+    this.assertOverlayActive();
+    this.emitOpenSettings();
+    setTimeout(this.emitOpenSettings, 250);
+    setTimeout(this.emitOpenSettings, 1000);
+  };
+
+  private fillMouseDisplay() {
+    if (!this.window) return;
+
+    const bounds = getMouseDisplayBounds();
+    this.window.setBounds(bounds);
+  }
+
   assertGameActive = () => {
+    if (this.bypassGameWindow) {
+      this.isInteractable = false;
+      this.poeWindow.isActive = false;
+      this.pendingSettingsOpen = false;
+      this.emitHideExclusiveWidget();
+      this.emitFocusState();
+      this.window?.hide();
+      return;
+    }
+
     if (this.isInteractable) {
       this.isInteractable = false;
+      this.emitHideExclusiveWidget();
       OverlayController.focusTarget();
       this.poeWindow.isActive = true;
     }
@@ -111,6 +263,13 @@ export class OverlayWindow {
 
   updateOpts(overlayKey: string, windowTitle: string) {
     this.overlayKey = overlayKey;
+    if (this.bypassGameWindow) {
+      this.server.sendEventTo("broadcast", {
+        name: "MAIN->OVERLAY::overlay-attached",
+        payload: undefined,
+      });
+      return;
+    }
     this.poeWindow.attach(this.window, windowTitle);
   }
 
@@ -185,4 +344,69 @@ export class OverlayWindow {
     });
     this.isOverlayKeyUsed = false;
   };
+
+  private emitFocusState() {
+    this.server.sendEventTo("broadcast", {
+      name: "MAIN->OVERLAY::focus-change",
+      payload: {
+        game: this.poeWindow.isActive,
+        overlay: this.isInteractable,
+        usingHotkey: this.isOverlayKeyUsed,
+      },
+    });
+    this.isOverlayKeyUsed = false;
+  }
+
+  private emitOpenSettings = () => {
+    this.server.sendEventTo("broadcast", {
+      name: "MAIN->CLIENT::open-settings",
+      payload: undefined,
+    });
+  };
+
+  private emitHideExclusiveWidget = () => {
+    this.server.sendEventTo("broadcast", {
+      name: "MAIN->OVERLAY::hide-exclusive-widget",
+      payload: undefined,
+    });
+  };
+}
+
+function getMouseDisplayBounds(): Rectangle {
+  return clampToDisplays(
+    screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).bounds,
+  );
+}
+
+function clampToDisplays(bounds: Rectangle): Rectangle {
+  const displays = screen.getAllDisplays();
+  const display =
+    displays.find((display) => intersects(bounds, display.bounds)) ??
+    screen.getDisplayNearestPoint({
+      x: bounds.x + Math.round(bounds.width / 2),
+      y: bounds.y + Math.round(bounds.height / 2),
+    });
+
+  const area = display.bounds;
+  return {
+    width: Math.min(bounds.width, area.width),
+    height: Math.min(bounds.height, area.height),
+    x: Math.min(
+      Math.max(bounds.x, area.x),
+      area.x + area.width - Math.min(bounds.width, area.width),
+    ),
+    y: Math.min(
+      Math.max(bounds.y, area.y),
+      area.y + area.height - Math.min(bounds.height, area.height),
+    ),
+  };
+}
+
+function intersects(a: Rectangle, b: Rectangle) {
+  return (
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
 }

--- a/native/linux-evdev-helper/Makefile
+++ b/native/linux-evdev-helper/Makefile
@@ -1,0 +1,25 @@
+CC ?= cc
+CFLAGS ?= -std=c11 -Wall -Wextra -Werror -O2
+PREFIX ?= /usr/local
+
+BIN := linux-evdev-helper
+DEBUG_BIN := linux-evdev-helper-debug
+SRC := linux-evdev-helper.c
+
+.PHONY: all clean debug install
+
+all: $(BIN)
+
+$(BIN): $(SRC)
+	$(CC) $(CFLAGS) -o $@ $<
+
+debug: $(DEBUG_BIN)
+
+$(DEBUG_BIN): $(SRC)
+	$(CC) $(CFLAGS) -DEE2_HELPER_DEBUG_EVENTS -o $@ $<
+
+install: $(BIN)
+	install -Dm755 $(BIN) "$(DESTDIR)$(PREFIX)/bin/$(BIN)"
+
+clean:
+	rm -f $(BIN) $(DEBUG_BIN)

--- a/native/linux-evdev-helper/NOTES.md
+++ b/native/linux-evdev-helper/NOTES.md
@@ -1,0 +1,61 @@
+# Linux evdev helper notes
+
+## Virtual keyboards and remappers
+
+Do not assume the physical keyboard event node is where usable key events are
+delivered.
+
+On systems using tools such as `keyd`, `kmonad`, `kanata`, interception tools,
+or other input remappers, the physical keyboard may still appear under
+`/dev/input/event*` and report normal key capabilities through `EVIOCGBIT`, but
+actual remapped key events can be emitted by a separate virtual keyboard device.
+
+Example observed setup:
+
+- Physical keyboard:
+  `/dev/input/event16` named `iQunix iQunix F96 Mechanical keyboard`
+- Virtual keyboard:
+  `/dev/input/event24` named `keyd virtual keyboard`
+
+The physical keyboard reported capabilities for Ctrl, D, N, Period, and Space,
+but did not emit the expected key events during testing. The actual events came
+from the `keyd virtual keyboard` device.
+
+## Discovery rule
+
+The app should launch the helper with the union of:
+
+- devices explicitly saved in config
+- keyboard devices discovered from `/dev/input/by-path` and `/dev/input/by-id`
+- current `/dev/input/event*` devices
+
+The helper still only emits configured hotkey activations, not arbitrary key
+streams, so watching additional input devices is acceptable for this backend.
+It is necessary for remapped keyboards and virtual input devices.
+
+## Debugging
+
+Debug event logging is not compiled into the normal helper binary. Build the
+separate debug binary first:
+
+```sh
+make -C native/linux-evdev-helper debug
+```
+
+Use the standalone wrapper:
+
+```sh
+cd main
+npm run test:linux-evdev-helper -- --debug-events
+```
+
+If needed, force every event device:
+
+```sh
+npm run test:linux-evdev-helper -- --debug-events --all-devices
+```
+
+In debug mode the helper prints opened device names, selected key
+capabilities, raw key events, current modifier state, and hotkey match attempts
+to stderr. Normal app launches and public builds should not include
+`--debug-events`.

--- a/native/linux-evdev-helper/linux-evdev-helper.c
+++ b/native/linux-evdev-helper/linux-evdev-helper.c
@@ -1,0 +1,721 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/input.h>
+#include <dirent.h>
+#include <limits.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define MAX_DEVICES 32
+#define MAX_HOTKEYS 128
+#define MAX_STRING 256
+#define CONFIG_LIMIT (128 * 1024)
+
+typedef struct {
+  bool ctrl;
+  bool shift;
+  bool alt;
+  bool meta;
+} ModState;
+
+typedef struct {
+  char id[MAX_STRING];
+  char accelerator[MAX_STRING];
+  int key_code;
+  ModState mods;
+} Hotkey;
+
+typedef struct {
+  pid_t parent_pid;
+  char devices[MAX_DEVICES][MAX_STRING];
+  size_t device_count;
+  Hotkey hotkeys[MAX_HOTKEYS];
+  size_t hotkey_count;
+} Config;
+
+static volatile sig_atomic_t should_stop = 0;
+#ifdef EE2_HELPER_DEBUG_EVENTS
+static bool debug_events = false;
+#endif
+
+static void on_signal(int signo) {
+  (void)signo;
+  should_stop = 1;
+}
+
+static void json_escape(FILE *out, const char *s) {
+  for (; *s; s++) {
+    if (*s == '"' || *s == '\\') {
+      fputc('\\', out);
+      fputc(*s, out);
+    } else if (*s == '\n') {
+      fputs("\\n", out);
+    } else if (*s == '\r') {
+      fputs("\\r", out);
+    } else if (*s == '\t') {
+      fputs("\\t", out);
+    } else {
+      fputc(*s, out);
+    }
+  }
+}
+
+static void emit_error(const char *code, const char *message, const char *device) {
+  printf("{\"type\":\"error\",\"code\":\"");
+  json_escape(stdout, code);
+  printf("\",\"message\":\"");
+  json_escape(stdout, message);
+  if (device != NULL) {
+    printf("\",\"device\":\"");
+    json_escape(stdout, device);
+  }
+  printf("\"}\n");
+  fflush(stdout);
+}
+
+static bool parse_pid_name(const char *name, pid_t *pid) {
+  char *end = NULL;
+  errno = 0;
+  long value = strtol(name, &end, 10);
+  if (errno != 0 || end == name || *end != '\0' || value <= 0) return false;
+  *pid = (pid_t)value;
+  return true;
+}
+
+static bool read_proc_exe_basename(pid_t pid, char *out, size_t out_len) {
+  char path[64];
+  char target[PATH_MAX];
+  snprintf(path, sizeof(path), "/proc/%ld/exe", (long)pid);
+
+  ssize_t len = readlink(path, target, sizeof(target) - 1);
+  if (len < 0) return false;
+  target[len] = '\0';
+
+  const char *base = strrchr(target, '/');
+  base = base == NULL ? target : base + 1;
+  if (strlen(base) + 1 > out_len) return false;
+  strcpy(out, base);
+  return true;
+}
+
+static bool is_process_alive(pid_t pid) {
+  return kill(pid, 0) == 0 || errno == EPERM;
+}
+
+static void sleep_ms(long ms) {
+  struct timespec delay;
+  delay.tv_sec = ms / 1000;
+  delay.tv_nsec = (ms % 1000) * 1000000L;
+  while (nanosleep(&delay, &delay) != 0 && errno == EINTR) {
+  }
+}
+
+static void kill_existing_helpers(void) {
+  DIR *proc = opendir("/proc");
+  if (proc == NULL) {
+    emit_error("replace-scan-failed", strerror(errno), NULL);
+    return;
+  }
+
+  pid_t self = getpid();
+  pid_t victims[256];
+  size_t victim_count = 0;
+  struct dirent *entry;
+
+  while ((entry = readdir(proc)) != NULL) {
+    pid_t pid;
+    char exe_name[64];
+    if (!parse_pid_name(entry->d_name, &pid)) continue;
+    if (pid == self) continue;
+    if (!read_proc_exe_basename(pid, exe_name, sizeof(exe_name))) continue;
+    if (strcmp(exe_name, "linux-evdev-helper") != 0) continue;
+    if (victim_count < sizeof(victims) / sizeof(victims[0])) {
+      victims[victim_count++] = pid;
+    }
+  }
+  closedir(proc);
+
+  for (size_t i = 0; i < victim_count; i++) {
+    if (kill(victims[i], SIGTERM) != 0 && errno != ESRCH) {
+      emit_error("replace-sigterm-failed", strerror(errno), NULL);
+    }
+  }
+
+  for (int attempt = 0; attempt < 20; attempt++) {
+    bool any_alive = false;
+    for (size_t i = 0; i < victim_count; i++) {
+      if (is_process_alive(victims[i])) {
+        any_alive = true;
+        break;
+      }
+    }
+    if (!any_alive) return;
+    sleep_ms(50);
+  }
+
+  for (size_t i = 0; i < victim_count; i++) {
+    if (is_process_alive(victims[i])) {
+      if (kill(victims[i], SIGKILL) != 0 && errno != ESRCH) {
+        emit_error("replace-sigkill-failed", strerror(errno), NULL);
+      }
+    }
+  }
+}
+
+static int key_code_for_name(const char *name) {
+  if (strlen(name) == 1) {
+    char c = name[0];
+    if (c >= 'A' && c <= 'Z') {
+      static const int letters[] = {
+        KEY_A, KEY_B, KEY_C, KEY_D, KEY_E, KEY_F, KEY_G, KEY_H, KEY_I,
+        KEY_J, KEY_K, KEY_L, KEY_M, KEY_N, KEY_O, KEY_P, KEY_Q, KEY_R,
+        KEY_S, KEY_T, KEY_U, KEY_V, KEY_W, KEY_X, KEY_Y, KEY_Z,
+      };
+      return letters[c - 'A'];
+    }
+    if (c >= '0' && c <= '9') {
+      static const int digits[] = {
+        KEY_0, KEY_1, KEY_2, KEY_3, KEY_4,
+        KEY_5, KEY_6, KEY_7, KEY_8, KEY_9,
+      };
+      return digits[c - '0'];
+    }
+  }
+
+  if (strncmp(name, "F", 1) == 0) {
+    char *end = NULL;
+    long n = strtol(name + 1, &end, 10);
+    if (end != name + 1 && *end == '\0' && n >= 1 && n <= 24) {
+      if (n <= 10) return KEY_F1 + (int)n - 1;
+      if (n == 11) return KEY_F11;
+      if (n == 12) return KEY_F12;
+      return KEY_F13 + (int)n - 13;
+    }
+  }
+
+  if (strcmp(name, "Space") == 0) return KEY_SPACE;
+  if (strcmp(name, "Enter") == 0) return KEY_ENTER;
+  if (strcmp(name, "Tab") == 0) return KEY_TAB;
+  if (strcmp(name, "Escape") == 0) return KEY_ESC;
+  if (strcmp(name, "Backspace") == 0) return KEY_BACKSPACE;
+  if (strcmp(name, "Delete") == 0) return KEY_DELETE;
+  if (strcmp(name, "Insert") == 0) return KEY_INSERT;
+  if (strcmp(name, "Home") == 0) return KEY_HOME;
+  if (strcmp(name, "End") == 0) return KEY_END;
+  if (strcmp(name, "PageUp") == 0) return KEY_PAGEUP;
+  if (strcmp(name, "PageDown") == 0) return KEY_PAGEDOWN;
+  if (strcmp(name, "ArrowLeft") == 0) return KEY_LEFT;
+  if (strcmp(name, "ArrowRight") == 0) return KEY_RIGHT;
+  if (strcmp(name, "ArrowUp") == 0) return KEY_UP;
+  if (strcmp(name, "ArrowDown") == 0) return KEY_DOWN;
+  if (strcmp(name, "Minus") == 0) return KEY_MINUS;
+  if (strcmp(name, "Equal") == 0) return KEY_EQUAL;
+  if (strcmp(name, "BracketLeft") == 0) return KEY_LEFTBRACE;
+  if (strcmp(name, "BracketRight") == 0) return KEY_RIGHTBRACE;
+  if (strcmp(name, "Backslash") == 0) return KEY_BACKSLASH;
+  if (strcmp(name, "Semicolon") == 0) return KEY_SEMICOLON;
+  if (strcmp(name, "Quote") == 0) return KEY_APOSTROPHE;
+  if (strcmp(name, "Backquote") == 0) return KEY_GRAVE;
+  if (strcmp(name, "Comma") == 0) return KEY_COMMA;
+  if (strcmp(name, "Period") == 0) return KEY_DOT;
+  if (strcmp(name, "Slash") == 0) return KEY_SLASH;
+  return -1;
+}
+
+static char *read_stdin_config(void) {
+  size_t cap = 4096;
+  size_t len = 0;
+  char *buf = malloc(cap);
+  if (buf == NULL) return NULL;
+
+  for (;;) {
+    if (len + 1024 + 1 > cap) {
+      cap *= 2;
+      if (cap > CONFIG_LIMIT) {
+        free(buf);
+        return NULL;
+      }
+      char *next = realloc(buf, cap);
+      if (next == NULL) {
+        free(buf);
+        return NULL;
+      }
+      buf = next;
+    }
+
+    size_t n = fread(buf + len, 1, 1024, stdin);
+    len += n;
+    if (n < 1024) {
+      if (ferror(stdin)) {
+        free(buf);
+        return NULL;
+      }
+      break;
+    }
+  }
+
+  buf[len] = '\0';
+  return buf;
+}
+
+static const char *skip_ws(const char *p) {
+  while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t') p++;
+  return p;
+}
+
+static const char *parse_json_string(const char *p, char *out, size_t out_len) {
+  p = skip_ws(p);
+  if (*p != '"') return NULL;
+  p++;
+
+  size_t n = 0;
+  while (*p && *p != '"') {
+    char c = *p++;
+    if (c == '\\') {
+      c = *p++;
+      if (c == 'n') c = '\n';
+      else if (c == 'r') c = '\r';
+      else if (c == 't') c = '\t';
+      else if (c == '\0') return NULL;
+    }
+    if (n + 1 >= out_len) return NULL;
+    out[n++] = c;
+  }
+
+  if (*p != '"') return NULL;
+  out[n] = '\0';
+  return p + 1;
+}
+
+static const char *find_key(const char *json, const char *key) {
+  char needle[64];
+  snprintf(needle, sizeof(needle), "\"%s\"", key);
+  return strstr(json, needle);
+}
+
+static bool parse_bool_after_key(const char *object, const char *key) {
+  const char *p = find_key(object, key);
+  if (p == NULL) return false;
+  p = strchr(p, ':');
+  if (p == NULL) return false;
+  p = skip_ws(p + 1);
+  return strncmp(p, "true", 4) == 0;
+}
+
+static bool parse_string_after_key(const char *object, const char *key, char *out, size_t out_len) {
+  const char *p = find_key(object, key);
+  if (p == NULL) return false;
+  p = strchr(p, ':');
+  if (p == NULL) return false;
+  return parse_json_string(p + 1, out, out_len) != NULL;
+}
+
+static bool parse_pid_after_key(const char *object, const char *key, pid_t *out) {
+  const char *p = find_key(object, key);
+  if (p == NULL) return false;
+  p = strchr(p, ':');
+  if (p == NULL) return false;
+  p = skip_ws(p + 1);
+
+  char *end = NULL;
+  errno = 0;
+  long value = strtol(p, &end, 10);
+  if (errno != 0 || end == p || value <= 0) return false;
+  *out = (pid_t)value;
+  return true;
+}
+
+static bool parse_devices(const char *json, Config *config) {
+  const char *p = find_key(json, "devices");
+  if (p == NULL) return false;
+  p = strchr(p, '[');
+  if (p == NULL) return false;
+  p++;
+
+  while (*p && *p != ']') {
+    if (config->device_count >= MAX_DEVICES) return false;
+    p = parse_json_string(p, config->devices[config->device_count], MAX_STRING);
+    if (p == NULL) return false;
+    config->device_count++;
+    p = skip_ws(p);
+    if (*p == ',') p++;
+  }
+
+  return config->device_count > 0;
+}
+
+static bool parse_hotkeys(const char *json, Config *config) {
+  const char *p = find_key(json, "hotkeys");
+  if (p == NULL) return false;
+  p = strchr(p, '[');
+  if (p == NULL) return false;
+  p++;
+
+  while (*p && *p != ']') {
+    p = skip_ws(p);
+    if (*p == ',') {
+      p++;
+      continue;
+    }
+    if (*p != '{') return false;
+
+    const char *end = strchr(p, '}');
+    if (end == NULL || config->hotkey_count >= MAX_HOTKEYS) return false;
+
+    char object[2048];
+    size_t len = (size_t)(end - p + 1);
+    if (len >= sizeof(object)) return false;
+    memcpy(object, p, len);
+    object[len] = '\0';
+
+    Hotkey *hotkey = &config->hotkeys[config->hotkey_count];
+    char key[MAX_STRING];
+    if (!parse_string_after_key(object, "id", hotkey->id, sizeof(hotkey->id)) ||
+        !parse_string_after_key(object, "accelerator", hotkey->accelerator, sizeof(hotkey->accelerator)) ||
+        !parse_string_after_key(object, "key", key, sizeof(key))) {
+      return false;
+    }
+    hotkey->key_code = key_code_for_name(key);
+    if (hotkey->key_code < 0) return false;
+    hotkey->mods.ctrl = parse_bool_after_key(object, "ctrl");
+    hotkey->mods.shift = parse_bool_after_key(object, "shift");
+    hotkey->mods.alt = parse_bool_after_key(object, "alt");
+    hotkey->mods.meta = parse_bool_after_key(object, "meta");
+    config->hotkey_count++;
+
+    p = end + 1;
+  }
+
+  return config->hotkey_count > 0;
+}
+
+static bool parse_config(const char *json, Config *config) {
+  memset(config, 0, sizeof(*config));
+  return parse_pid_after_key(json, "parentPid", &config->parent_pid) &&
+         parse_devices(json, config) &&
+         parse_hotkeys(json, config);
+}
+
+static bool is_ctrl_key(int code) {
+  return code == KEY_LEFTCTRL || code == KEY_RIGHTCTRL;
+}
+
+static bool is_shift_key(int code) {
+  return code == KEY_LEFTSHIFT || code == KEY_RIGHTSHIFT;
+}
+
+static bool is_alt_key(int code) {
+  return code == KEY_LEFTALT || code == KEY_RIGHTALT;
+}
+
+static bool is_meta_key(int code) {
+  return code == KEY_LEFTMETA || code == KEY_RIGHTMETA;
+}
+
+static bool mods_match(const ModState *actual, const ModState *wanted) {
+  return actual->ctrl == wanted->ctrl &&
+         actual->shift == wanted->shift &&
+         actual->alt == wanted->alt &&
+         actual->meta == wanted->meta;
+}
+
+static bool bit_is_set(const unsigned long *bits, int bit) {
+  return (bits[bit / (int)(8 * sizeof(unsigned long))] &
+          (1UL << (bit % (int)(8 * sizeof(unsigned long))))) != 0;
+}
+
+#ifdef EE2_HELPER_DEBUG_EVENTS
+static bool device_has_key(int fd, int key) {
+  unsigned long keys[(KEY_MAX + 8 * sizeof(unsigned long)) / (8 * sizeof(unsigned long))];
+  memset(keys, 0, sizeof(keys));
+  if (ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keys)), keys) < 0) return false;
+  return bit_is_set(keys, key);
+}
+#endif
+
+static bool read_mod_state(int fd, ModState *mods) {
+  unsigned long keys[(KEY_MAX + 8 * sizeof(unsigned long)) / (8 * sizeof(unsigned long))];
+  memset(keys, 0, sizeof(keys));
+  if (ioctl(fd, EVIOCGKEY(sizeof(keys)), keys) < 0) return false;
+
+  mods->ctrl = bit_is_set(keys, KEY_LEFTCTRL) || bit_is_set(keys, KEY_RIGHTCTRL);
+  mods->shift = bit_is_set(keys, KEY_LEFTSHIFT) || bit_is_set(keys, KEY_RIGHTSHIFT);
+  mods->alt = bit_is_set(keys, KEY_LEFTALT) || bit_is_set(keys, KEY_RIGHTALT);
+  mods->meta = bit_is_set(keys, KEY_LEFTMETA) || bit_is_set(keys, KEY_RIGHTMETA);
+  return true;
+}
+
+static int open_devices(const Config *config, int fds[MAX_DEVICES], struct pollfd polls[MAX_DEVICES]) {
+  for (size_t i = 0; i < config->device_count; i++) {
+    if (strncmp(config->devices[i], "/dev/input/event", 16) != 0 ||
+        config->devices[i][16] < '0' ||
+        config->devices[i][16] > '9') {
+      emit_error("invalid-device", "device path must start with /dev/input/event", config->devices[i]);
+      for (size_t j = 0; j < i; j++) close(fds[j]);
+      return -1;
+    }
+
+    int fd = open(config->devices[i], O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+      emit_error("open-device-failed", strerror(errno), config->devices[i]);
+      for (size_t j = 0; j < i; j++) close(fds[j]);
+      return -1;
+    }
+#ifdef EE2_HELPER_DEBUG_EVENTS
+    if (debug_events) {
+      char name[256] = {0};
+      if (ioctl(fd, EVIOCGNAME(sizeof(name)), name) < 0) {
+        snprintf(name, sizeof(name), "unknown: %s", strerror(errno));
+      }
+      fprintf(
+        stderr,
+        "opened device=%s name=\"%s\" has_keys={ctrl:%d d:%d n:%d period:%d space:%d}\n",
+        config->devices[i],
+        name,
+        device_has_key(fd, KEY_LEFTCTRL) || device_has_key(fd, KEY_RIGHTCTRL),
+        device_has_key(fd, KEY_D),
+        device_has_key(fd, KEY_N),
+        device_has_key(fd, KEY_DOT),
+        device_has_key(fd, KEY_SPACE)
+      );
+      fflush(stderr);
+    }
+#endif
+    fds[i] = fd;
+    polls[i].fd = fd;
+    polls[i].events = POLLIN;
+    polls[i].revents = 0;
+  }
+
+  return 0;
+}
+
+static int check_permissions(const Config *config) {
+  if (geteuid() != 0) {
+    emit_error("not-root", "linux-evdev-helper must run as root", NULL);
+    return 1;
+  }
+
+  int fds[MAX_DEVICES];
+  struct pollfd polls[MAX_DEVICES];
+  if (open_devices(config, fds, polls) != 0) return 1;
+  for (size_t i = 0; i < config->device_count; i++) close(fds[i]);
+  printf("{\"type\":\"permissions\",\"ok\":true,\"devices\":%zu}\n", config->device_count);
+  return 0;
+}
+
+static void emit_ready(const Config *config) {
+  printf("{\"type\":\"ready\",\"devices\":[");
+  for (size_t i = 0; i < config->device_count; i++) {
+    if (i) printf(",");
+    printf("\"");
+    json_escape(stdout, config->devices[i]);
+    printf("\"");
+  }
+  printf("],\"hotkeys\":%zu}\n", config->hotkey_count);
+  fflush(stdout);
+}
+
+static void emit_hotkey(const Hotkey *hotkey, const struct input_event *event) {
+  long long ts = ((long long)event->time.tv_sec * 1000LL) + ((long long)event->time.tv_usec / 1000LL);
+  printf("{\"type\":\"hotkey\",\"id\":\"");
+  json_escape(stdout, hotkey->id);
+  printf("\",\"accelerator\":\"");
+  json_escape(stdout, hotkey->accelerator);
+  printf("\",\"ts\":%lld}\n", ts);
+  fflush(stdout);
+}
+
+#ifdef EE2_HELPER_DEBUG_EVENTS
+static void debug_raw_key_event(
+  const char *device,
+  const struct input_event *event
+) {
+  if (!debug_events) return;
+  fprintf(
+    stderr,
+    "raw-key device=%s code=%u value=%d\n",
+    device,
+    event->code,
+    event->value
+  );
+  fflush(stderr);
+}
+#endif
+
+#ifdef EE2_HELPER_DEBUG_EVENTS
+static void debug_key_event(
+  const char *device,
+  const struct input_event *event,
+  const ModState *mods
+) {
+  if (!debug_events) return;
+  fprintf(
+    stderr,
+    "event device=%s type=%u code=%u value=%d mods={ctrl:%d shift:%d alt:%d meta:%d}\n",
+    device,
+    event->type,
+    event->code,
+    event->value,
+    mods->ctrl,
+    mods->shift,
+    mods->alt,
+    mods->meta
+  );
+  fflush(stderr);
+}
+#endif
+
+#ifdef EE2_HELPER_DEBUG_EVENTS
+static void debug_match_attempt(const Hotkey *hotkey, const struct input_event *event, const ModState *mods) {
+  if (!debug_events) return;
+  fprintf(
+    stderr,
+    "match? id=%s accelerator=%s event_code=%u wanted_code=%d wanted_mods={ctrl:%d shift:%d alt:%d meta:%d} actual_mods={ctrl:%d shift:%d alt:%d meta:%d}\n",
+    hotkey->id,
+    hotkey->accelerator,
+    event->code,
+    hotkey->key_code,
+    hotkey->mods.ctrl,
+    hotkey->mods.shift,
+    hotkey->mods.alt,
+    hotkey->mods.meta,
+    mods->ctrl,
+    mods->shift,
+    mods->alt,
+    mods->meta
+  );
+  fflush(stderr);
+}
+#endif
+
+static int run_helper(const Config *config) {
+  if (geteuid() != 0) {
+    emit_error("not-root", "linux-evdev-helper must run as root", NULL);
+    return 1;
+  }
+
+  int fds[MAX_DEVICES];
+  struct pollfd polls[MAX_DEVICES];
+  if (open_devices(config, fds, polls) != 0) return 1;
+
+  signal(SIGTERM, on_signal);
+  signal(SIGINT, on_signal);
+  emit_ready(config);
+
+  while (!should_stop) {
+    if (!is_process_alive(config->parent_pid)) {
+      break;
+    }
+
+    int ready = poll(polls, (nfds_t)config->device_count, 500);
+    if (ready < 0) {
+      if (errno == EINTR) continue;
+      emit_error("poll-failed", strerror(errno), NULL);
+      break;
+    }
+    if (ready == 0) continue;
+
+    for (size_t i = 0; i < config->device_count; i++) {
+      if ((polls[i].revents & POLLIN) == 0) continue;
+
+      struct input_event event;
+      ssize_t n = read(fds[i], &event, sizeof(event));
+      if (n != (ssize_t)sizeof(event)) continue;
+      if (event.type != EV_KEY) continue;
+#ifdef EE2_HELPER_DEBUG_EVENTS
+      debug_raw_key_event(config->devices[i], &event);
+#endif
+      if (event.value != 1) continue;
+      if (is_ctrl_key(event.code) || is_shift_key(event.code) || is_alt_key(event.code) || is_meta_key(event.code)) {
+        continue;
+      }
+
+      ModState mods = {0};
+      if (!read_mod_state(fds[i], &mods)) {
+        emit_error("read-key-state-failed", strerror(errno), config->devices[i]);
+        continue;
+      }
+#ifdef EE2_HELPER_DEBUG_EVENTS
+      debug_key_event(config->devices[i], &event, &mods);
+#endif
+
+      for (size_t j = 0; j < config->hotkey_count; j++) {
+        const Hotkey *hotkey = &config->hotkeys[j];
+#ifdef EE2_HELPER_DEBUG_EVENTS
+        debug_match_attempt(hotkey, &event, &mods);
+#endif
+        if (event.code == hotkey->key_code && mods_match(&mods, &hotkey->mods)) {
+          emit_hotkey(hotkey, &event);
+        }
+      }
+    }
+  }
+
+  for (size_t i = 0; i < config->device_count; i++) close(fds[i]);
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  if (argc > 1 && strcmp(argv[1], "--version") == 0) {
+    printf("linux-evdev-helper 0.1.0\n");
+    return 0;
+  }
+
+  bool replace_existing = false;
+  bool check_permissions_mode = false;
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--replace-existing") == 0) {
+      replace_existing = true;
+    } else if (strcmp(argv[i], "--check-permissions") == 0) {
+      check_permissions_mode = true;
+#ifdef EE2_HELPER_DEBUG_EVENTS
+    } else if (strcmp(argv[i], "--debug-events") == 0) {
+      debug_events = true;
+#endif
+    } else {
+      emit_error("invalid-argument", "unsupported command-line argument", argv[i]);
+      return 1;
+    }
+  }
+
+  char *json = read_stdin_config();
+  if (json == NULL) {
+    emit_error("read-config-failed", "failed to read helper configuration from stdin", NULL);
+    return 1;
+  }
+
+  Config config;
+  if (!parse_config(json, &config)) {
+    free(json);
+    emit_error("invalid-config", "helper configuration is invalid or unsupported", NULL);
+    return 1;
+  }
+  free(json);
+
+  if (check_permissions_mode) {
+    return check_permissions(&config);
+  }
+
+  if (replace_existing) {
+    if (geteuid() != 0) {
+      emit_error("not-root", "linux-evdev-helper must run as root", NULL);
+      return 1;
+    }
+    kill_existing_helpers();
+  }
+
+  return run_helper(&config);
+}

--- a/renderer/package.json
+++ b/renderer/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 127.0.0.1 --port 5173 --strictPort",
     "check-types": "tsc --noemit",
     "lint": "eslint --ext .ts,.vue src",
     "lint-fix": "eslint --ext .ts,.vue src --fix",

--- a/renderer/src/main.ts
+++ b/renderer/src/main.ts
@@ -4,25 +4,46 @@ import * as I18n from "./web/i18n";
 import * as Data from "./assets/data";
 import { initConfig, AppConfig } from "./web/Config";
 import { Host } from "./web/background/IPC";
+
+function markBoot(step: string, error?: unknown) {
+  if (!import.meta.env.DEV) return;
+  (window as unknown as { __EE2_BOOT?: unknown }).__EE2_BOOT = {
+    step,
+    error: error instanceof Error ? error.message : String(error ?? ""),
+    at: Date.now(),
+  };
+}
+
 (async function () {
-  await initConfig();
-  const i18nPlugin = await I18n.init(AppConfig().language);
-  await Data.init(AppConfig().language);
-  await Host.init();
+  try {
+    markBoot("initConfig:start");
+    await initConfig();
+    markBoot("i18n:start");
+    const i18nPlugin = await I18n.init(AppConfig().language);
+    markBoot("data:start");
+    await Data.init(AppConfig().language);
+    markBoot("host:init");
+    await Host.init();
 
-  watch(
-    () => AppConfig().language,
-    async () => {
-      await Data.loadForLang(AppConfig().language);
-      await I18n.loadLang(AppConfig().language);
-    },
-  );
+    watch(
+      () => AppConfig().language,
+      async () => {
+        await Data.loadForLang(AppConfig().language);
+        await I18n.loadLang(AppConfig().language);
+      },
+    );
 
-  const app = createApp(App);
-  app.use(i18nPlugin);
-  app.mount("#app");
-  if (import.meta.env.DEV) {
-    app.config.performance = true;
-    console.error("DEV MODE");
+    markBoot("mount:start");
+    const app = createApp(App);
+    app.use(i18nPlugin);
+    app.mount("#app");
+    markBoot("mounted");
+    if (import.meta.env.DEV) {
+      app.config.performance = true;
+      console.error("DEV MODE");
+    }
+  } catch (error) {
+    markBoot("error", error);
+    console.error(error);
   }
 })();

--- a/renderer/src/web/Config.ts
+++ b/renderer/src/web/Config.ts
@@ -128,6 +128,7 @@ export interface Config {
   configVersion: number;
   leagueId?: string;
   overlayKey: string;
+  linuxShortcutBackend?: HostConfig["linuxShortcutBackend"];
   overlayBackground: string;
   overlayBackgroundClose: boolean;
   restoreClipboard: boolean;
@@ -800,6 +801,9 @@ function getConfigForHost(): HostConfig {
 
   return {
     shortcuts: actions,
+    linuxShortcutBackend:
+      config.linuxShortcutBackend ??
+      linuxShortcutBackendFromEnv(),
     restoreClipboard: config.restoreClipboard,
     clientLog: config.clientLog,
     gameConfig: config.gameConfig,
@@ -812,5 +816,30 @@ function getConfigForHost(): HostConfig {
     libraryAlpha: config.enableAlphas && config.alphas.includes("library"),
     libraryOutputPath: library.libraryOutputPath,
     initialDelay: priceCheck.initialDelay,
+  };
+}
+
+function linuxShortcutBackendFromEnv(): HostConfig["linuxShortcutBackend"] {
+  const backend = import.meta.env.VITE_LINUX_HOTKEY_BACKEND;
+  if (backend !== "linux-evdev-helper") return undefined;
+
+  return {
+    backend,
+    mode:
+      import.meta.env.VITE_LINUX_HOTKEY_BACKEND_MODE === "fallback"
+        ? "fallback"
+        : "enabled",
+    elevation:
+      import.meta.env.VITE_LINUX_HOTKEY_ELEVATION === "none" ||
+      import.meta.env.VITE_LINUX_HOTKEY_ELEVATION === "sudo"
+        ? import.meta.env.VITE_LINUX_HOTKEY_ELEVATION
+        : "pkexec",
+    helperPath: import.meta.env.VITE_LINUX_HOTKEY_HELPER || undefined,
+    devices: import.meta.env.VITE_LINUX_HOTKEY_DEVICES
+      ? import.meta.env.VITE_LINUX_HOTKEY_DEVICES.split(",")
+          .map((device: string) => device.trim())
+          .filter(Boolean)
+      : undefined,
+    enableUinput: false,
   };
 }

--- a/renderer/src/web/background/IPC.ts
+++ b/renderer/src/web/background/IPC.ts
@@ -1,6 +1,7 @@
 import type {
   IpcEvent,
   IpcEventPayload,
+  LinuxHotkeyHelperDebugEvent,
   UpdateInfo,
   HostState,
 } from "@ipc/types";
@@ -13,6 +14,16 @@ class HostTransport {
   logs = shallowRef("");
   version = shallowRef("0.0.00000");
   updateInfo = shallowRef<UpdateInfo>({ state: "initial" });
+  linuxHotkeyHelperEventLog = shallowRef("");
+  linuxHotkeyHelper = shallowRef<HostState["linuxHotkeyHelper"]>({
+    isWayland: false,
+    configured: false,
+    running: false,
+    elevation: "pkexec",
+    command: null,
+    capturing: [],
+    error: null,
+  });
 
   async init() {
     this.onEvent("MAIN->CLIENT::log-entry", (entry) => {
@@ -20,6 +31,12 @@ class HostTransport {
     });
     this.onEvent("MAIN->CLIENT::updater-state", (info) => {
       this.updateInfo.value = info;
+    });
+    this.onEvent("MAIN->CLIENT::linux-hotkey-helper-state", (state) => {
+      this.linuxHotkeyHelper.value = state;
+    });
+    this.onEvent("MAIN->CLIENT::linux-hotkey-helper-debug-event", (event) => {
+      this.appendLinuxHotkeyHelperEvent(event);
     });
     await new Promise((resolve) => {
       this.socket = new Sockette(`ws://${window.location.host}/events`, {
@@ -29,6 +46,25 @@ class HostTransport {
         onopen: resolve,
       });
     });
+  }
+
+  private appendLinuxHotkeyHelperEvent(event: LinuxHotkeyHelperDebugEvent) {
+    const time = new Date(event.at).toLocaleTimeString();
+    const fields = [
+      event.kind,
+      event.id ? `id=${event.id}` : null,
+      event.accelerator ? `accelerator=${event.accelerator}` : null,
+      event.code ? `code=${event.code}` : null,
+      event.device ? `device=${event.device}` : null,
+      event.exitCode !== undefined ? `exitCode=${event.exitCode}` : null,
+      event.signal ? `signal=${event.signal}` : null,
+      event.helperTs !== undefined ? `helperTs=${event.helperTs}` : null,
+      event.message,
+    ].filter(Boolean);
+    const lines = `${this.linuxHotkeyHelperEventLog.value}${time} ${fields.join(
+      " ",
+    )}\n`.split("\n");
+    this.linuxHotkeyHelperEventLog.value = lines.slice(-200).join("\n");
   }
 
   selfDispatch(event: IpcEvent) {
@@ -68,6 +104,7 @@ class HostTransport {
     // TODO: refactor this
     this.version.value = config.version;
     this.updateInfo.value = config.updater;
+    this.linuxHotkeyHelper.value = config.linuxHotkeyHelper;
     return config.contents;
   }
 

--- a/renderer/src/web/overlay/OverlayWindow.vue
+++ b/renderer/src/web/overlay/OverlayWindow.vue
@@ -95,6 +95,7 @@ export default defineComponent({
     const gameFocused = shallowRef(false);
     const hideUI = shallowRef(false);
     const showEditingNotification = shallowRef(false);
+    const pendingOpenSettings = shallowRef(false);
 
     watch(active, (active) => {
       if (active) {
@@ -110,6 +111,7 @@ export default defineComponent({
         AppConfig().widgets = value;
       },
     });
+    watch(widgets, () => openSettingsIfReady(), { deep: true });
 
     window.addEventListener("blur", () => {
       nextTick(() => {
@@ -126,6 +128,17 @@ export default defineComponent({
     Host.onEvent("MAIN->CLIENT::config-changed", () => {
       const widget = topmostOrExclusiveWidget.value;
       if (widget.wmType === "settings") {
+        hide(widget.wmId);
+      }
+    });
+    Host.onEvent("MAIN->CLIENT::open-settings", () => {
+      pendingOpenSettings.value = true;
+      openSettingsIfReady();
+      nextTick(openSettingsIfReady);
+    });
+    Host.onEvent("MAIN->OVERLAY::hide-exclusive-widget", () => {
+      const widget = topmostOrExclusiveWidget.value;
+      if (widget.wmZorder === "exclusive") {
         hide(widget.wmId);
       }
     });
@@ -174,6 +187,7 @@ export default defineComponent({
           payload: { isOverlay: Host.isElectron },
         });
         pushHostConfig();
+        openSettingsIfReady();
       });
     });
 
@@ -198,6 +212,16 @@ export default defineComponent({
         hide(topmostWidget.wmId);
       }
       widgets.value.find((_) => _.wmId === wmId)!.wmWants = "show";
+    }
+
+    function openSettingsIfReady() {
+      if (!pendingOpenSettings.value) return;
+      const settings = widgets.value.find((w) => w.wmType === "settings");
+      if (!settings) return;
+
+      active.value = true;
+      show(settings.wmId);
+      pendingOpenSettings.value = false;
     }
 
     function hide(wmId: WMID) {

--- a/renderer/src/web/settings/SettingsWindow.vue
+++ b/renderer/src/web/settings/SettingsWindow.vue
@@ -373,19 +373,21 @@ function flatJoin<T, J>(arr: T[][], joinEl: () => J) {
 <style lang="postcss" module>
 .window {
   position: absolute;
-  top: 0;
-  bottom: 0;
+  top: 50%;
+  bottom: auto;
   left: 0;
   right: 0;
   margin: 0 auto;
+  transform: translateY(-50%);
+  flex-grow: 0;
   max-width: 50rem;
-  max-height: 38rem;
+  height: min(38rem, calc(100% - 4rem)) !important;
   overflow: hidden;
   @apply bg-gray-800;
-  @apply rounded-b;
+  @apply rounded;
 
   &:global {
-    animation-name: slideInDown;
+    animation-name: fadeIn;
     animation-duration: 1s;
   }
 }
@@ -421,7 +423,7 @@ function flatJoin<T, J>(arr: T[][], joinEl: () => J) {
 .patronsHorizontal {
   @apply bg-gray-900 p-1 rounded gap-1;
   position: absolute;
-  top: 40rem;
+  top: calc(50% + min(19rem, calc((100% - 4rem) / 2)) + 1.25rem);
   left: 0;
   right: 0;
   margin: 0 auto;

--- a/renderer/src/web/settings/hotkeys.vue
+++ b/renderer/src/web/settings/hotkeys.vue
@@ -17,6 +17,58 @@
         }}</ui-radio>
       </div>
     </div>
+    <div
+      v-if="linuxHotkeyHelper.isWayland"
+      class="mt-8 border-t border-gray-600 pt-4"
+    >
+      <div class="mb-2 flex items-center justify-between gap-3">
+        <div class="font-fontin text-lg">Wayland hotkey helper</div>
+        <button
+          class="rounded bg-gray-700 px-3 py-1 hover:bg-gray-600"
+          type="button"
+          @click="restartLinuxHotkeyHelper"
+        >
+          Restart
+        </button>
+      </div>
+      <div class="space-y-2 text-sm">
+        <div>
+          Helper running as root:
+          <span
+            :class="
+              linuxHotkeyHelper.running ? 'text-green-400' : 'text-red-400'
+            "
+          >
+            {{ linuxHotkeyHelper.running ? "yes" : "no" }}
+          </span>
+        </div>
+        <div class="break-all">
+          Command:
+          <code class="rounded bg-gray-900 px-1 py-0.5">{{
+            linuxHotkeyHelper.command ?? "not configured"
+          }}</code>
+        </div>
+        <div v-if="linuxHotkeyHelper.error" class="text-red-300">
+          {{ linuxHotkeyHelper.error }}
+        </div>
+        <div>
+          Capturing:
+          <span v-if="linuxHotkeyHelper.capturing.length">
+            {{ linuxHotkeyHelper.capturing.join(", ") }}
+          </span>
+          <span v-else>no app hotkeys configured</span>
+        </div>
+      </div>
+      <div class="mt-4">
+        <div class="mb-1 font-fontin text-base">Helper event log</div>
+        <textarea
+          id="linux-hotkey-helper-event-log"
+          class="h-32 w-full resize-y rounded bg-gray-900 p-2 font-mono text-xs text-gray-200"
+          readonly
+          :value="linuxHotkeyHelperEventLog"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -29,6 +81,7 @@ export default {
 <script setup lang="ts">
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { MainProcess } from "@/web/background/IPC";
 import {
   configProp,
   configModelValue,
@@ -94,6 +147,17 @@ const hotkeys = computed<HotkeySchema[]>(() => {
 });
 
 const stashScroll = configModelValue(() => props.config, "stashScroll");
+const linuxHotkeyHelper = computed(() => MainProcess.linuxHotkeyHelper.value);
+const linuxHotkeyHelperEventLog = computed(
+  () => MainProcess.linuxHotkeyHelperEventLog.value,
+);
+
+function restartLinuxHotkeyHelper() {
+  MainProcess.sendEvent({
+    name: "CLIENT->MAIN::user-action",
+    payload: { action: "restart-linux-hotkey-helper" },
+  });
+}
 
 const { t } = useI18n();
 </script>


### PR DESCRIPTION
Demo of an end to end implementation of global hotkeys working in wayland by bypassing the compositor entirely and using a helper tool running as root.

## How it works
Exiled Exchange 2 normally uses Electron global shortcuts for app hotkeys. On
Wayland, global hotkeys are compositor and portal dependent, and shortcuts can
fail while Path of Exile has focus. The optional `linux-evdev-helper` backend
delegates hotkey capture to a small native helper that reads configured
`/dev/input/event*` keyboard devices with evdev.

This backend is Linux-only and opt-in. The Electron/Node process does not read
input devices directly and must not be run as root. The native helper runs as
root by default through an explicit privilege prompt, then reports only
configured hotkey activations to Node over stdout as newline-delimited JSON.

## Details

- [Linux evdev helper README](/docs/linux-evdev-helper.md)
- [evdev helper implementation notes](/native/linux-evdev-helper/NOTES.md)

## Screencast
This is me triggering the overlay with the SHIFT+N hotkey while running KDE Plasma 6 in Wayland mode.

[Screencast_20260613_115827.webm](https://github.com/user-attachments/assets/d0123dd3-6625-4306-ada8-f747532bb7ea)


## Disclaimer

Although this "works" I haven't tested it end to end with AppImage, with the normal build output unpacked, or with non wayland systems to make sure none of this stuff runs if wayland isn't detected so for now this is just a beta. However if you are talented with this type of code you can probably get it working on your wayland box right now.