### PR TITLE
Wayland

### DIFF
--- a/docs/data-parsing.md
+++ b/docs/data-parsing.md
@@ -1,0 +1,456 @@
+# Data Parsing — Analysis, Root Causes, and What Was Fixed
+
+The price data pipeline in `renderer/src/web/background/Prices.ts` uses manual
+string searching against raw JSON text instead of parsing it. This approach is
+fragile, has several confirmed bugs that cause runtime crashes, and contains a
+broken cache that never hits. This document describes what the code is actually
+doing, where each brittleness lives, and a plan to replace it.
+
+---
+
+## What the data looks like
+
+Three endpoints are fetched on every price refresh:
+
+### `item-drop.json`
+A plain JSON array of `DropEntry` objects. Parsed normally with `JSON.parse`.
+No issues here.
+
+### `namespaceMap.json`
+A small JSON object:
+```json
+{
+  "schemaVersion": 1,
+  "map": [
+    { "ns": "ITEM", "cx": true,  "url": "currency",  "type": "Currency" },
+    { "ns": "ITEM", "cx": false, "url": "unique-map", "type": "UniqueMap" }
+  ]
+}
+```
+Also parsed normally. No issues.
+
+### `overviewData.json`
+The large blob. **This is valid JSON** with the following top-level shape:
+```json
+{
+  "core": {
+    "rates": { "exalted": 2312, "chaos": 76.2 },
+    "primary": "divine",
+    "secondary": "chaos"
+  },
+  "itemOverviews": [
+    {
+      "type": "Currency",
+      "lines": [
+        {
+          "name": "Orb of Alchemy",
+          "detailsId": "orb-of-alchemy",
+          "id": "alch",
+          "primaryValue": 0.00003575,
+          "volumePrimaryValue": 0.4008,
+          "maxVolumeCurrency": "exalted",
+          "maxVolumeRate": 12.05,
+          "sparkline": { "totalChange": -40.89, "data": [...] }
+        },
+        ...
+      ]
+    },
+    { "type": "UniqueMap", "lines": [...] },
+    ...
+  ]
+}
+```
+
+The code never calls `JSON.parse` on this object as a whole. Instead it treats
+it as a raw string and performs text searches on it. Everything below is a
+consequence of that decision.
+
+---
+
+## The three parsing functions
+
+### `parseXchg(jsonBlob)` — extract exchange rates
+
+```typescript
+const RATES = '{"rates":';
+const END_RATES = '"}';
+const startPos = jsonBlob.indexOf(RATES);
+const endPos = jsonBlob.indexOf(END_RATES, startPos) + END_RATES.length;
+return JSON.parse(jsonBlob.slice(startPos, endPos));
+```
+
+**What it searches for:** the literal string `{"rates":` inside the blob, then
+the first occurrence of `"}` (a quote followed by a closing brace) after that
+position to determine where the object ends.
+
+**Why it works today:** the `"core"` object ends with `"secondary":"chaos"}`.
+The sequence `"}` (the closing `"` of `"chaos"` followed by the closing `}` of
+the core object) is what `END_RATES` matches. The slice captures the full core
+object and parses correctly.
+
+**Where it breaks:**
+
+1. `END_RATES = '"}'` is two characters. It matches the first `"}` sequence
+   after `{"rates":`, regardless of nesting. Any string value in the core
+   object that ends with a `"` before a `}` would cause the slice to terminate
+   too early and produce a malformed JSON fragment. Example: if `primary` were
+   ever `"div}"`, the match fires immediately.
+
+2. If `{"rates":` is absent from the blob (format change, network truncation),
+   `startPos = -1`. `jsonBlob.slice(-1, ...)` returns a one-character tail of
+   the blob. `JSON.parse` throws with a useless error.
+
+3. The extracted object is `NinjaXchgRates` but the slice contains the raw
+   `"core"` object. The interface matches only because `"rates"`, `"primary"`,
+   and `"secondary"` happen to be the only keys. Any future key added to `core`
+   is silently ignored — fine for now but undocumented.
+
+---
+
+### `splitJsonBlob(jsonBlob, schema)` — split into sections
+
+```typescript
+const NINJA_OVERVIEW = '{"type":"';
+let startPos = jsonBlob.indexOf(NINJA_OVERVIEW);
+while (true) {
+  const endPos = jsonBlob.indexOf(NINJA_OVERVIEW, startPos + 1);
+  const type = jsonBlob.slice(
+    startPos + NINJA_OVERVIEW.length,
+    jsonBlob.indexOf('"', startPos + NINJA_OVERVIEW.length),
+  );
+  const lines = jsonBlob.slice(startPos, endPos === -1 ? jsonBlob.length : endPos);
+  // ...
+}
+```
+
+**What it searches for:** the literal string `{"type":"` as a section boundary.
+Each occurrence is treated as the start of a new price section. The section's
+type name is extracted by finding the next `"` after the marker. The raw text
+from one `{"type":"` to the next is stored as `lines` in the `PriceDatabase`.
+
+**Why it works today:** poe.ninja formats every section header as
+`{"type":"Currency","lines":[...]}` with `"type"` as the first key. No item
+name, detailsId, or other string value in the current dataset happens to
+contain `{"type":"` as a literal substring.
+
+**Where it breaks:**
+
+1. Any item whose `name`, `detailsId`, or any string field contains the literal
+   text `{"type":"` would be misidentified as a section boundary. The section
+   containing that item would be split at the wrong position, corrupting both
+   the section before and after it.
+
+2. If the server ever reorders keys so that `"type"` is not the first key in
+   a section object (e.g., `{"id":1,"type":"Currency"}`), the function finds
+   nothing and returns an empty database.
+
+3. The `lines` string stored for each section includes the full section wrapper
+   `{"type":"Currency","lines":[...]}`. This raw string is then used by
+   `findPriceByQuery`, which means that function must avoid false matches on
+   `"type":"Currency"` itself.
+
+---
+
+### `findPriceByQuery(query)` — look up a single item price
+
+```typescript
+const searchString = JSON.stringify({
+  name: query.name,
+  variant: query.variant,
+  primaryValue: 0,
+}).replace(":0}", ":");
+const endSearchString = "}}";
+
+const startPos = lines.indexOf(searchString);
+const endPos = lines.indexOf(endSearchString, startPos);
+const info = JSON.parse(lines.slice(startPos, endPos + endSearchString.length));
+```
+
+**What it searches for:** a JSON key prefix constructed from `name`, optionally
+`variant`, and `primaryValue`. The prefix looks like one of:
+
+```
+{"name":"Orb of Alchemy","primaryValue":
+{"name":"Vaal Orb","variant":"Corrupted","primaryValue":
+```
+
+The trailing `0` is stripped by the `.replace(":0}", ":")` so the prefix ends
+just before the value, allowing it to match any `primaryValue` regardless of
+its actual number. The end of the object is found by searching for `}}`.
+
+**Why it works today (or doesn't):** the server must return item objects with
+`name` (and optionally `variant`) as the first fields, immediately followed by
+`primaryValue`. If the server emits `"detailsId"` or any other key between
+`"name"` and `"primaryValue"`, the search string never matches and the function
+returns null for every item. The `NinjaDenseExchangeInfo` interface lists
+`detailsId` as a field, but this code never finds it via search — it must come
+after `primaryValue` in the actual JSON for this to work at all.
+
+This key-ordering dependency is undocumented, not enforced by any schema, and
+silently breaks whenever poe.ninja changes their serialization order.
+
+**Where it breaks:**
+
+1. **Key ordering.** As described. If `"detailsId"` or any other field appears
+   between `"name"` and `"primaryValue"` in the server output, `indexOf`
+   returns -1. `lines.slice(-1, 1)` produces a single character.
+   `JSON.parse` throws `SyntaxError`. **This is the observed crash.**
+
+2. **`}}` end marker.** `"sparkline"` contains a `"data"` array and a
+   `"totalChange"` field. The sparkline object closes with `}`. The outer item
+   object also closes with `}`. So `}}` appears naturally at the end of each
+   item. But `}}` could also appear earlier — for example, if `"data"` is
+   `[{},{}]` (hypothetical nested objects), or if future fields add nested
+   objects. A premature match produces a truncated JSON fragment that either
+   parses to a partial object or throws.
+
+3. **No error handling at the call site.** `findPriceByQuery` is called from
+   `cachedCurrencyByQuery`, which is called from Vue price-check components.
+   None of these callers have try/catch. A throw from `JSON.parse` propagates
+   as an uncaught promise rejection in the component context, which is why the
+   error surfaces as `[Renderer:3] Uncaught (in promise) SyntaxError` rather
+   than the `[Renderer:2] console.warn` that `load()`'s catch block would
+   produce.
+
+---
+
+## The broken cache
+
+```typescript
+let priceCache = new Map<
+  { ns: string; name: string; count: number },
+  CurrencyValue
+>();
+
+function cachedCurrencyByQuery(query: DbQuery, count: number) {
+  const key = { ns: query.ns, name: query.name, count };
+  if (priceCache.has(key)) { ... }  // never true
+  priceCache.set(key, currency);
+```
+
+`Map.has()` uses reference equality for object keys. A new object literal is
+created on every call, so `priceCache.has(key)` is always false. The cache
+accumulates entries that are never read. Every price lookup hits the O(n)
+string search every time.
+
+---
+
+## Summary of bugs
+
+| Location | Bug | Effect |
+|----------|-----|--------|
+| `parseXchg` | `END_RATES = '"}'` matches 2 chars | Wrong slice if any string value ends `"X"}` |
+| `parseXchg` | No guard when `RATES` not found | `slice(-1,...)` + meaningless JSON.parse error |
+| `splitJsonBlob` | `{"type":"` matches inside string values | Section corruption if any item contains this literal |
+| `splitJsonBlob` | Depends on `"type"` being the first key | Silent empty database if key order changes |
+| `findPriceByQuery` | Assumes `name`→`primaryValue` are adjacent | Returns null or throws if server key order differs — **active crash** |
+| `findPriceByQuery` | `}}` end marker is not unique | Slice terminates at wrong object boundary |
+| `findPriceByQuery` | No error handling | SyntaxError propagates as uncaught rejection |
+| `cachedCurrencyByQuery` | Object literal as Map key | Cache never hits; O(n) search on every lookup |
+
+---
+
+## Replacement plan
+
+The blob is valid JSON. Parse it once, build indexes, do O(1) lookups.
+
+### Step 1 — parse the blob properly
+
+Replace all string-search extraction with a single `JSON.parse`:
+
+```typescript
+interface OverviewBlob {
+  core: {
+    rates: Record<string, number>;
+    primary: string;
+    secondary: string;
+  };
+  itemOverviews: Array<{
+    type: string;
+    lines: Array<NinjaDenseExchangeInfo | NinjaDenseStashInfo>;
+  }>;
+}
+
+const blob: OverviewBlob = JSON.parse(jsonText);
+```
+
+This eliminates `parseXchg` and `splitJsonBlob` entirely. The `core` object is
+directly available. Each section's `lines` is an already-parsed array, not a
+raw string.
+
+### Step 2 — build a lookup index
+
+Replace the `PriceDatabase` raw-string store and the O(n) `findPriceByQuery`
+search with a Map:
+
+```typescript
+type PriceIndex = Map<
+  string,  // key: `${ns}:${name}:${variant ?? ""}`
+  { entry: NinjaDenseExchangeInfo | NinjaDenseStashInfo; cx: boolean; url: string }
+>;
+```
+
+Built at load time:
+
+```typescript
+const index: PriceIndex = new Map();
+for (const section of blob.itemOverviews) {
+  const mapping = schema.map.find((m) => m.type === section.type);
+  if (!mapping) continue;
+  for (const item of section.lines) {
+    const key = `${mapping.ns}:${item.name}:${item.variant ?? ""}`;
+    index.set(key, { entry: item, cx: mapping.cx, url: mapping.url });
+  }
+}
+```
+
+Lookup becomes:
+
+```typescript
+function findPriceByQuery(query: DbQuery) {
+  const key = `${query.ns}:${query.name}:${query.variant ?? ""}`;
+  const hit = index.get(key);
+  if (!hit) return null;
+  return {
+    ...hit.entry,
+    cx: hit.cx,
+    url: `https://poe.ninja/poe2/economy/${selectedLeagueToUrl(false)}/${hit.url}/${hit.entry.detailsId}`,
+  };
+}
+```
+
+O(1) lookup, no string slicing, no JSON.parse at query time, no key-ordering
+assumption, no `}}` boundary heuristic.
+
+### Step 3 — fix the cache
+
+Change the cache key to a string:
+
+```typescript
+const priceCache = new Map<string, CurrencyValue>();
+
+function cachedCurrencyByQuery(query: DbQuery, count: number) {
+  const key = `${query.ns}:${query.name}:${query.variant ?? ""}:${count}`;
+  if (priceCache.has(key)) return priceCache.get(key)!;
+  ...
+}
+```
+
+### Step 4 — add error handling to `load()`
+
+The existing `catch (e) { console.warn(e); }` already suppresses errors inside
+`load()`. The new code won't throw from `findPriceByQuery`, but add a guard
+anyway so component-level calls are safe:
+
+```typescript
+function findPriceByQuery(query: DbQuery) {
+  if (!index.size) return null;
+  const key = `${query.ns}:${query.name}:${query.variant ?? ""}`;
+  return index.get(key) ?? null;
+}
+```
+
+### No new library needed for Prices.ts
+
+The blob is standard JSON. `JSON.parse` handles it. The fast-search problem is
+an indexing problem, not a parsing problem — a `Map` gives O(1) keyed lookup
+with zero dependencies. A streaming JSON parser (e.g., `@streamparser/json`)
+would only help if the blob were too large to hold in memory, which it isn't.
+
+**Status: implemented** in `renderer/src/web/background/Prices.ts`.
+
+---
+
+## NDJSON item/stat data (`assets/data/index.ts`)
+
+### What it was doing
+
+`loadItems` and `loadStats` fetched three files each:
+
+1. A `.ndjson` file (newline-delimited JSON, one record per line)
+2. Two `.index.bin` files — binary `Uint32Array` tables mapping FNV1a-32 hashes
+   to **byte offsets** into the `.ndjson` text
+
+Lookups worked by:
+1. Computing `fnv1a(key, {size: 32})` → hash
+2. Binary-searching the index for that hash → row
+3. Reading `index[row * 2 + 1]` → byte offset
+4. Slicing the raw NDJSON string from that offset to the next `\n`
+5. Calling `JSON.parse` on the slice
+
+### Why it was broken
+
+**CRLF line endings.** The `.ndjson` files are stored with Windows line endings
+(`\r\n`). The binary index files were built against LF-only versions of those
+files. Byte offsets stored in the index are therefore wrong by `(N − 1)` bytes
+for the Nth line: the stored offset lands inside the content of the previous
+line rather than at the start of the target line.
+
+For a lookup that resolved to line N=6, the stored offset was 5 bytes before
+the actual line 6 start. That position fell on the `f` of `false}` (a common
+JSON boolean value at the end of the previous line). `JSON.parse("false}...")` →
+`SyntaxError: Unexpected non-whitespace character after JSON at position 5`.
+This surfaced as `[Renderer:3] Uncaught (in promise) SyntaxError` during
+`init()`, which has no try/catch.
+
+Secondary issues with the old approach regardless of CRLF:
+- FNV1a-32 has a non-trivial collision rate over ~4000+ entries; collisions
+  silently returned the wrong record
+- `ndjsonFindLines` did O(n) string search on the raw text for every iterator
+  call, and used the same fragile `start`/`end`/`slice` pattern
+- `itemNamesFromLines` built a concatenated string to iterate names, using
+  the same `start`/`end` slice loop
+
+### What replaced it
+
+Three small helpers and two rewritten load functions. No binary index files,
+no byte offsets, no string slicing.
+
+```typescript
+// Parse an NDJSON text into a typed array.
+// Splits on \n; JSON.parse handles trailing \r as whitespace.
+function parseNdjson<T>(text: string): T[] {
+  const out: T[] = [];
+  for (const line of text.split("\n")) {
+    if (line.trim()) out.push(JSON.parse(line) as T);
+  }
+  return out;
+}
+
+// Iterator that pattern-matches against pre-serialized JSON strings.
+function makeIterator<T>(items: T[], serialized: string[]) {
+  return function* (searchString: string, andIncludes: string[] = []) {
+    for (let i = 0; i < items.length; i++) {
+      if (serialized[i].includes(searchString) &&
+          andIncludes.every((s) => serialized[i].includes(s))) {
+        yield items[i];
+      }
+    }
+  };
+}
+
+// Name generator over a filtered item subset.
+function makeNameGenerator(items: BaseType[]): () => Generator<string> {
+  return function* () { for (const item of items) yield item.name; };
+}
+```
+
+**`loadItems`** fetches `items.ndjson`, calls `parseNdjson`, then builds:
+- `Map<"${ns}::${name}", BaseType[]>` → `ITEM_BY_TRANSLATED`
+- `Map<"${ns}::${refName}", BaseType[]>` → `ITEM_BY_REF`
+- `makeIterator` over the parsed array → `ITEMS_ITERATOR`
+- Filtered name generators → `GEM_NS_NAMES`, `UNIQUE_NS_NAMES`, `ITEM_NS_NAMES`
+- Iterates parsed items directly for `TRADE_TAG_TO_REF`
+
+**`loadStats`** fetches `stats.ndjson`, calls `parseNdjson`, then builds:
+- `Map<ref, Stat>` → `STAT_BY_REF`
+- `Map<matcherString, {stat, matcher}>` → `STAT_BY_MATCH_STR`
+- `makeIterator` over the parsed array → `STATS_ITERATOR`
+
+Removed entirely: `dataBinarySearch`, `ndjsonFindLines`, `itemNamesFromLines`,
+the `fnv1a` import, and all `.index.bin` fetches. The `.index.bin` files in
+`public/data/` are now unused dead weight and can be deleted from the repo.
+
+All exported function signatures are unchanged. No callers needed updates.
+
+**Status: implemented** in `renderer/src/assets/data/index.ts`.

--- a/docs/wayland.md
+++ b/docs/wayland.md
@@ -1,0 +1,342 @@
+# Electron BrowserWindow API on Wayland — Reference for EE2 Overlay
+
+Traced against Electron (Chromium 151.0.7894.0) source at
+`~/Sources/electron`. All file references are relative to that repo.
+
+---
+
+## Method-by-method trace
+
+### `show()`
+
+**Source:** `shell/browser/native_window_views.cc:587`
+
+```cpp
+void NativeWindowViews::Show() {
+  widget()->native_widget_private()->Show(GetRestoredState(), gfx::Rect());
+  widget()->Activate();   // explicit activation request
+  NotifyWindowShow();
+  if (x11_util::IsX11())
+    widget()->SetZOrderLevel(widget()->GetZOrderLevel());
+}
+```
+
+`widget()->Activate()` calls `platform_window()->Activate()`, which on Wayland
+issues an `xdg_activation_v1` token request to the compositor. Whether the
+compositor grants focus is up to it. KWin honors the request only when it
+considers the token valid (i.e., it originated from a genuine user interaction
+event on the current active surface). Activation requests that arrive without a
+compositor-endorsed token may be silently ignored or cause KWin to flash the
+taskbar entry instead.
+
+**Official docs note:** "On Wayland (Linux), the desktop environment may show
+a notification or flash the app icon if the window or app is not already
+focused."
+
+**Verdict:** Works on Wayland. Maps the surface and requests focus. Whether
+focus is granted depends on compositor focus-stealing prevention policy. Do
+not use `show()` when you want the overlay to appear without disturbing the
+focused game — see the EE2 pattern below.
+
+---
+
+### `showInactive()`
+
+**Source:** `shell/browser/native_window_views.cc:609`
+
+```cpp
+void NativeWindowViews::ShowInactive() {
+  widget()->ShowInactive();   // no Activate() call
+  NotifyWindowShow();
+  if (x11_util::IsX11())
+    widget()->SetZOrderLevel(widget()->GetZOrderLevel());
+}
+```
+
+Unlike `Show()`, this does not call `Activate()`. The intent is to map the
+window surface without requesting focus.
+
+**Official docs:** `win.showInactive()` — **"Not supported on Wayland (Linux)."**
+
+On Wayland the behavior is undefined. There is no `xdg_toplevel` protocol
+equivalent of X11's `_NET_WM_USER_TIME` suppress-activation hint. In practice
+the window may map without focus or may behave identically to `show()`.
+
+**Verdict:** Officially unsupported. Behavior is undefined on Wayland. Do not
+rely on it.
+
+---
+
+### `focus()`
+
+**Source:** `shell/browser/native_window_views.cc:571`
+
+```cpp
+void NativeWindowViews::Focus(bool focus) {
+  if (!IsVisible()) return;   // no-op if window is hidden
+  if (focus) {
+    widget()->Activate();
+  } else {
+    widget()->Deactivate();
+  }
+}
+```
+
+**Critical guard:** `focus()` is a silent no-op if the window is not yet
+visible. Always call `show()` first.
+
+On Wayland, `Activate()` sends another `xdg_activation_v1` request. Against a
+fullscreen game, KWin either denies it (overlay stays unfocused) or briefly
+grants it (game immediately fights to reclaim focus). Either outcome is wrong
+for an overlay that is supposed to sit passively on top of a running game.
+
+**Verdict:** Functionally works on Wayland when the window is visible. Do NOT
+use it in a game overlay context — it sends a compositor activation request
+that creates a focus battle with the game. See EE2 findings below.
+
+---
+
+### `hide()`
+
+**Source:** `shell/browser/native_window_views.cc:625`
+
+```cpp
+void NativeWindowViews::Hide() {
+  widget()->Hide();
+  NotifyWindowHide();
+}
+```
+
+Clean, no platform guards. Unmaps the Wayland surface. The compositor returns
+keyboard focus to whichever window previously held it.
+
+**Verdict:** Works correctly on Wayland. The preferred close mechanism for an
+overlay.
+
+---
+
+### `moveTop()`
+
+**Source:** `shell/browser/native_window_views.cc:1035`
+
+```cpp
+void NativeWindowViews::MoveTop() {
+  // TODO(julien.isorce): fix chromium in order to use existing widget()->StackAtTop().
+#if BUILDFLAG(IS_WIN)
+  ::SetWindowPos(..., SWP_NOACTIVATE | ...);
+#else
+  if (x11_util::IsX11())
+    electron::MoveWindowToForeground(static_cast<x11::Window>(...));
+#endif
+}
+```
+
+The Wayland branch is entirely absent.
+
+**Official docs:** `win.moveTop()` — **"Not supported on Wayland (Linux)."**
+
+**Verdict:** Confirmed no-op on Wayland.
+
+---
+
+### `setAlwaysOnTop(true, level)`
+
+**Source:** `shell/browser/api/electron_api_base_window.cc:569`,
+`shell/browser/native_window_views.cc:1169`
+
+```cpp
+void BaseWindow::SetAlwaysOnTop(bool top, gin::Arguments* args) {
+  std::string level = "floating";
+  ui::ZOrderLevel z_order =
+      top ? ui::ZOrderLevel::kFloatingWindow : ui::ZOrderLevel::kNormal;
+  window_->SetAlwaysOnTop(z_order, level, relative_level);
+}
+
+void NativeWindowViews::SetAlwaysOnTop(
+    const ui::ZOrderLevel z_order,
+    const std::string& level,
+    const int relativeLevel) {
+  widget()->SetZOrderLevel(z_order);
+  // level string only used for Windows behind_task_bar_ logic
+}
+```
+
+**The `level` parameter (`"screen-saver"` etc.) is `_macOS_ _Windows_` only.**
+On Linux the string is silently discarded. All truthy level values map
+identically to `ui::ZOrderLevel::kFloatingWindow`.
+
+`widget()->SetZOrderLevel(kFloatingWindow)` goes through Chromium's ozone
+layer to the Wayland platform window. The compositor effect is undefined —
+there is no `zwlr_layer_shell_v1` in use.
+
+**Official docs:** `win.setAlwaysOnTop()` — **"Not supported on Wayland (Linux)."**
+
+**Verdict:** Level string has no effect on Linux. The boolean may produce a
+compositor-dependent stacking hint. Set it once at window creation and do not
+toggle it on every show/hide: each `SetZOrderLevel` call routes to the platform
+window and may trigger a compositor recompositing cycle, which on some versions
+of KWin manifests as a brief focus change.
+
+---
+
+### `setVisibleOnAllWorkspaces(true)`
+
+**Source:** `shell/browser/api/electron_api_base_window.cc:817`,
+`shell/browser/native_window_views.cc:1681`
+
+```cpp
+void NativeWindowViews::SetVisibleOnAllWorkspaces(
+    bool visible,
+    bool visibleOnFullScreen,
+    bool skipTransformProcessType) {
+  widget()->SetVisibleOnAllWorkspaces(visible);
+  // visibleOnFullScreen and skipTransformProcessType silently ignored on Linux
+}
+```
+
+**`visibleOnFullScreen: true` is `_macOS_` only.** On Linux the option is
+accepted at the JS layer and discarded before the native call. The `visible`
+boolean does have effect on Wayland via whatever sticky-workspace protocol the
+compositor supports.
+
+**Verdict:** Works on Linux. The boolean is operative. The `visibleOnFullScreen`
+option does nothing on Linux — omit it or pass it for macOS compatibility only.
+
+---
+
+### `setIgnoreMouseEvents(bool)`
+
+**Source:** `shell/browser/native_window_views.cc:1371`
+
+```cpp
+void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
+#if BUILDFLAG(IS_WIN)
+  // WS_EX_TRANSPARENT | WS_EX_LAYERED
+#else
+  if (x11_util::IsX11()) {
+    // X11 Shape extension — sets a 1x1 input region
+  }
+#endif
+}
+```
+
+The Wayland branch is entirely absent.
+
+**Verdict:** Confirmed no-op on Wayland. Mouse passthrough cannot be controlled
+from Electron on Wayland. Surface visibility (`hide()`) is the only available
+input suppression mechanism.
+
+---
+
+### `globalShortcut.register()` on Wayland
+
+`globalShortcut` is not a BrowserWindow method but its behavior on Wayland is
+critical for EE2.
+
+On a Wayland session that includes XWayland (which PoE2 runs under), Electron's
+`globalShortcut.register()` falls back to `XGrabKey` on the X11 display. This
+has two consequences:
+
+1. **Double-fire.** Any shortcut registered via `globalShortcut` that is also
+   handled by the evdev helper fires twice: once from the evdev helper and once
+   from the `globalShortcut` callback. The `globalShortcut` callback has no
+   `poeWindow.isActive` gate — it calls `runAction()` unconditionally. For
+   `toggle-overlay` this means the overlay opens and immediately closes in the
+   same event cycle.
+
+2. **XGrabKey interference.** `XGrabKey` temporarily diverts the grabbed keys
+   away from the focused XWayland window (PoE2). This disrupts PoE2's own key
+   handling and can manifest as input stuttering or focus loss in the game.
+
+**Verdict:** Do not call `globalShortcut.register()` on Wayland. The evdev
+helper (`linux-evdev-wayland-helper`) is the correct hotkey backend for
+Wayland and already handles all registered actions.
+
+---
+
+## Summary table
+
+| API | Wayland status | Notes |
+|-----|---------------|-------|
+| `show()` | Works | Requests focus via xdg_activation_v1; may fight fullscreen game |
+| `showInactive()` | **Not supported** | Officially unsupported; undefined behavior |
+| `focus()` | Works (if visible) | Sends activation request; causes focus battle with fullscreen game |
+| `hide()` | Works | Clean surface unmap; compositor returns focus to previous window |
+| `moveTop()` | **No-op** | No Wayland code path |
+| `setAlwaysOnTop(true, level)` | Partial | Level string ignored; bool may have compositor-dependent effect |
+| `setVisibleOnAllWorkspaces(true)` | Works | `visibleOnFullScreen` param is macOS-only, ignored on Linux |
+| `setIgnoreMouseEvents(bool)` | **No-op** | No Wayland code path; use `hide()` instead |
+| `globalShortcut.register()` | **Do not use** | Falls back to XGrabKey; double-fires with evdev helper, disrupts XWayland input |
+
+---
+
+## EE2 overlay pattern on Wayland
+
+### What went wrong and why
+
+**`electron-overlay-window` calling `showInactive()` on XWayland focus events.**
+`OverlayController.attachByTitle(window, title)` stores a reference to the
+Electron BrowserWindow and registers internal listeners on the library's event
+emitter. When the library's native X11 code detects PoE2 (running under
+XWayland) gaining focus, it calls `this.electronWindow.showInactive()` directly
+— bypassing all application-level guards. On a Wayland session this caused the
+overlay to appear every time PoE2 gained focus, with no way to stop it short of
+not calling `attachByTitle`. Fix: skip `OverlayController.attachByTitle()` on
+Wayland entirely. `GameWindow.attach()` gates the call with `!isWayland()`.
+
+**`globalShortcut` double-firing toggle actions.**
+After each `assertGameActive()` call, `poeWindow.isActive` changes to `true`,
+which fires `active-change(true)`, which triggers `Shortcuts.register()`. On
+Wayland this was registering all actions via `globalShortcut`, which uses
+XGrabKey under XWayland. The `globalShortcut` callback calls `runAction()`
+with no activity gate. Combined with the evdev helper also firing the same
+hotkey, `toggle-overlay` would open and immediately close. Fix:
+`Shortcuts.register()` and `unregister()` now return early on Wayland.
+
+**`focus()` and `setAlwaysOnTop` toggling causing activation fights.**
+Calling `focus()` after `show()` sends `xdg_activation_v1`. Against a
+fullscreen game this either fails silently (overlay stays unfocused) or
+triggers a brief focus steal that PoE2 immediately reverses — causing the blur
+handler to fire, which hides the overlay, which re-registers shortcuts, which
+re-caused the problem above. Separately, toggling `setAlwaysOnTop` on every
+show/hide call causes KWin to re-evaluate the window's compositor layer on
+each call, which can manifest as a focus event. Fix: `focus()` is not called
+on Wayland; `setAlwaysOnTop` is called once at window creation.
+
+**`moveTop()` and `setIgnoreMouseEvents()` being no-ops.**
+Both were present in earlier iterations of the code. Neither has a Wayland
+code path. Removed.
+
+### The correct Wayland pattern for EE2
+
+**Window creation (once):**
+```typescript
+new BrowserWindow({
+  show: false, frame: false, transparent: true,
+  alwaysOnTop: true, focusable: true, skipTaskbar: true,
+  ...
+})
+window.setAlwaysOnTop(true)           // set once; never toggled
+window.setVisibleOnAllWorkspaces(true) // set once; never toggled
+```
+
+**Open:**
+```typescript
+window.setBounds(display.bounds)
+window.show()   // maps surface; no focus() call — game keeps keyboard focus
+```
+
+**Close:**
+```typescript
+window.hide()   // unmaps surface; compositor returns focus to game
+```
+
+**Hotkeys:** evdev helper (`linux-evdev-wayland-helper`) only. `globalShortcut`
+is not registered on Wayland.
+
+**Game focus tracking:** `GameWindow._isActive` is initialized to `true` on
+Wayland (game assumed focused at startup). `OverlayWindow.assertOverlayActive()`
+sets it `false`; `assertGameActive()` sets it `true`. `OverlayController`
+focus/blur events are ignored on Wayland — the library's X11 detection is
+unreliable in a mixed Wayland/XWayland session and its `attachByTitle` path
+would call `showInactive()` on our window.

--- a/ipc/types.ts
+++ b/ipc/types.ts
@@ -88,6 +88,7 @@ export type IpcEvent =
   | IpcLogEntry
   | IpcHostConfig
   | IpcWidgetAction
+  | IpcShowSettings
   | IpcItemText
   | IpcOcrText
   | IpcConfigChanged
@@ -108,6 +109,7 @@ type IpcFocusChange = Event<
     game: boolean;
     overlay: boolean;
     usingHotkey: boolean;
+    isWayland: boolean;
   }
 >;
 
@@ -170,6 +172,8 @@ type IpcWidgetAction = Event<
     target: string;
   }
 >;
+
+type IpcShowSettings = Event<"MAIN->CLIENT::show-settings">;
 
 type IpcItemText = Event<
   "MAIN->CLIENT::item-text",

--- a/main/build/script.mjs
+++ b/main/build/script.mjs
@@ -1,8 +1,18 @@
 import child_process from 'child_process'
 import electron from 'electron'
 import esbuild from 'esbuild'
+import fs from 'fs'
+import path from 'path'
 
 const isDev = !process.argv.includes('--prod')
+const debugPort = process.env.EE2_REMOTE_DEBUGGING_PORT || '9222'
+const debugDir = path.resolve('.debug')
+const electronLogPath = path.join(debugDir, 'electron.log')
+const chromiumLogPath = path.join(debugDir, 'chromium.log')
+
+if (isDev) {
+  fs.mkdirSync(debugDir, { recursive: true })
+}
 
 const electronRunner = (() => {
   let handle = null
@@ -11,9 +21,42 @@ const electronRunner = (() => {
       console.info('Restarting Electron process.')
 
       if (handle) handle.kill()
-      handle = child_process.spawn(electron, ['.'], {
-        stdio: 'inherit'
+      const args = (isDev)
+        ? [
+            '.',
+            `--remote-debugging-port=${debugPort}`,
+            '--enable-logging=file',
+            `--log-file=${chromiumLogPath}`
+          ]
+        : ['.']
+      const env = {
+        ...process.env,
+        ELECTRON_ENABLE_LOGGING: (isDev) ? '1' : process.env.ELECTRON_ENABLE_LOGGING
+      }
+
+      if (isDev) {
+        fs.appendFileSync(
+          electronLogPath,
+          `\n[${new Date().toISOString()}] Starting Electron with remote debugging on http://127.0.0.1:${debugPort}\n`
+        )
+        console.info(`Electron remote debugging: http://127.0.0.1:${debugPort}`)
+        console.info(`Electron log: ${electronLogPath}`)
+        console.info(`Chromium log: ${chromiumLogPath}`)
+      }
+
+      handle = child_process.spawn(electron, args, {
+        env,
+        stdio: (isDev) ? ['inherit', 'pipe', 'pipe'] : 'inherit'
       })
+
+      if (isDev) {
+        const logStream = fs.createWriteStream(electronLogPath, { flags: 'a' })
+        handle.stdout.pipe(process.stdout)
+        handle.stderr.pipe(process.stderr)
+        handle.stdout.pipe(logStream)
+        handle.stderr.pipe(logStream)
+        handle.on('close', () => logStream.end())
+      }
     }
   }
 })()
@@ -30,7 +73,7 @@ const mainContext = await esbuild.context({
   bundle: true,
   minify: !isDev,
   platform: 'node',
-  external: ['electron', 'uiohook-napi', 'electron-overlay-window'],
+  external: ['electron', 'uiohook-napi', 'electron-overlay-window', 'linux-evdev-wayland-helper'],
   outfile: 'dist/main.js',
   define: {
     'process.env.STATIC': (isDev) ? '"../build/icons"' : '"."',

--- a/main/electron-builder.yml
+++ b/main/electron-builder.yml
@@ -4,11 +4,14 @@ productName: "Exiled Exchange 2"
 npmRebuild: false
 files:
   - "package.json"
+  - "node_modules/linux-evdev-wayland-helper/**/*"
   - from: "dist"
     to: "."
     filter: ["main.js", "vision.js"]
   - from: "../renderer/dist"
     to: "."
+asarUnpack:
+  - "node_modules/linux-evdev-wayland-helper/native/linux-evdev-helper/linux-evdev-helper"
 extraMetadata:
   main: "main.js"
 nsis:

--- a/main/package-lock.json
+++ b/main/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.15.8",
       "dependencies": {
         "electron-overlay-window": "4.0.2",
+        "linux-evdev-wayland-helper": "^0.2.1",
         "uiohook-napi": "1.5.x"
       },
       "devDependencies": {
@@ -5496,6 +5497,18 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/linux-evdev-wayland-helper": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/linux-evdev-wayland-helper/-/linux-evdev-wayland-helper-0.2.1.tgz",
+      "integrity": "sha512-DwbGIx3FnQE23mzCN0Mfb8DhfEt+XYCxHehbwsG5cTLT+3c3qBFLua9dmIJ6lOnBRcy2RFRPk3M5W49WufZdHQ==",
+      "license": "MIT",
+      "bin": {
+        "linux-evdev-helper-test": "scripts/linux-evdev-helper-test.mjs"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/locate-path": {

--- a/main/package.json
+++ b/main/package.json
@@ -21,6 +21,7 @@
   "main": "dist/main.js",
   "dependencies": {
     "electron-overlay-window": "4.0.2",
+    "linux-evdev-wayland-helper": "^0.2.1",
     "uiohook-napi": "1.5.x"
   },
   "devDependencies": {

--- a/main/src/AppTray.ts
+++ b/main/src/AppTray.ts
@@ -4,6 +4,8 @@ import type { ServerEvents } from "./server";
 
 export class AppTray {
   public overlayKey = "Shift + Space";
+  public suppressOverlayHide?: () => void;
+  public openSettings?: () => void;
   private tray: Tray;
   serverPort = 0;
 
@@ -24,6 +26,9 @@ export class AppTray {
 
     this.tray = new Tray(trayImage);
     this.tray.setToolTip(`Exiled Exchange 2 v${app.getVersion()}`);
+    this.tray.on("right-click", () => {
+      this.suppressOverlayHide?.();
+    });
     this.rebuildMenu();
 
     server.onEventAnyClient("CLIENT->MAIN::user-action", ({ action }) => {
@@ -38,6 +43,11 @@ export class AppTray {
       {
         label: "Settings/League",
         click: () => {
+          if (isWayland()) {
+            this.openSettings?.();
+            return;
+          }
+
           dialog.showMessageBox({
             title: "Settings",
             message: `Open Path of Exile 2 and press "${this.overlayKey}". Click on the button with cog icon there.`,
@@ -67,4 +77,12 @@ export class AppTray {
 
     this.tray.setContextMenu(contextMenu);
   }
+}
+
+function isWayland(): boolean {
+  return (
+    process.platform === "linux" &&
+    (process.env.XDG_SESSION_TYPE === "wayland" ||
+      Boolean(process.env.WAYLAND_DISPLAY))
+  );
 }

--- a/main/src/host-files/ConfigStore.ts
+++ b/main/src/host-files/ConfigStore.ts
@@ -4,7 +4,6 @@ import fs from "fs/promises";
 import path from "path";
 
 export class ConfigStore {
-  private isTmpFile = false;
   private cfgPath = path.join(
     app.getPath("userData"),
     "apt-data",
@@ -30,15 +29,10 @@ export class ConfigStore {
   }
 
   private async save(contents: string, tmp: boolean) {
-    if (process.env.VITE_DEV_SERVER_URL) return;
-
-    if (tmp && !this.isTmpFile) {
-      this.cfgPath += ".tmp";
-      this.isTmpFile = true;
-    }
+    const cfgPath = tmp ? `${this.cfgPath}.tmp` : this.cfgPath;
     try {
-      await fs.mkdir(path.dirname(this.cfgPath), { recursive: true });
-      await fs.writeFile(this.cfgPath, contents);
+      await fs.mkdir(path.dirname(cfgPath), { recursive: true });
+      await fs.writeFile(cfgPath, contents);
     } catch {
       app.exit(1);
     }

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -92,6 +92,16 @@ let tray: AppTray;
     setTimeout(
       async () => {
         const overlay = new OverlayWindow(eventPipe, logger, poeWindow);
+        tray.suppressOverlayHide = () => {
+          overlay.suppressNextDeactivate();
+        };
+        tray.openSettings = () => {
+          overlay.assertOverlayActive({ force: true });
+          eventPipe.sendEventTo("broadcast", {
+            name: "MAIN->CLIENT::show-settings",
+            payload: undefined,
+          });
+        };
         // eslint-disable-next-line no-new
         new OverlayVisibility(eventPipe, overlay, gameConfig);
         const shortcuts = await Shortcuts.create(

--- a/main/src/shortcuts/Shortcuts.ts
+++ b/main/src/shortcuts/Shortcuts.ts
@@ -247,9 +247,12 @@ export class Shortcuts {
     }));
 
     const hotkeysKey = JSON.stringify(hotkeys);
-    if (hotkeysKey === this.linuxHelperHotkeysKey && this.linuxHelperRunning) return;
+    if (hotkeysKey === this.linuxHelperHotkeysKey && this.linuxHelperRunning)
+      return;
     this.linuxHelperHotkeysKey = hotkeysKey;
-    this.linuxHelperActions = new Map(eligible.map((action, i) => [`action-${i}`, action]));
+    this.linuxHelperActions = new Map(
+      eligible.map((action, i) => [`action-${i}`, action]),
+    );
 
     if (!this.linuxHelper) {
       this.linuxHelper = new LinuxEvdevHelper();
@@ -269,7 +272,9 @@ export class Shortcuts {
           parentPid: process.pid,
         });
 
-    this.logger.write(`info [linux-evdev-helper] ${this.linuxHelperRunning ? "updating" : "starting"} ${hotkeys.length} hotkeys`);
+    this.logger.write(
+      `info [linux-evdev-helper] ${this.linuxHelperRunning ? "updating" : "starting"} ${hotkeys.length} hotkeys`,
+    );
     work
       .then(() => {
         this.linuxHelperRunning = true;
@@ -277,7 +282,9 @@ export class Shortcuts {
       .catch((error) => {
         this.linuxHelperRunning = false;
         this.linuxHelperHotkeysKey = null;
-        this.logger.write(`error [linux-evdev-helper] ${(error as Error).message}`);
+        this.logger.write(
+          `error [linux-evdev-helper] ${(error as Error).message}`,
+        );
       });
   }
 

--- a/main/src/shortcuts/Shortcuts.ts
+++ b/main/src/shortcuts/Shortcuts.ts
@@ -1,5 +1,7 @@
 import { app, screen, globalShortcut } from "electron";
 import path from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
 import {
   LinuxEvdevHelper,
   type LinuxEvdevHelperEvent,
@@ -261,21 +263,28 @@ export class Shortcuts {
       });
     }
 
-    const work = this.linuxHelperRunning
-      ? this.linuxHelper.setHotkeys(hotkeys)
-      : this.linuxHelper.start({
-          helperPath: getLinuxEvdevHelperPath(),
+    const isStarting = !this.linuxHelperRunning;
+    this.logger.write(
+      `info [linux-evdev-helper] ${isStarting ? "starting" : "updating"} ${hotkeys.length} hotkeys`,
+    );
+
+    const doWork = async () => {
+      const helperPath = await stageHelperBinary(getLinuxEvdevHelperPath());
+      if (this.linuxHelperRunning) {
+        await this.linuxHelper!.setHotkeys(hotkeys);
+      } else {
+        await this.linuxHelper!.start({
+          helperPath,
           hotkeys,
           allDevices: true,
           elevation: "pkexec",
           enableUinput: false,
           parentPid: process.pid,
         });
+      }
+    };
 
-    this.logger.write(
-      `info [linux-evdev-helper] ${this.linuxHelperRunning ? "updating" : "starting"} ${hotkeys.length} hotkeys`,
-    );
-    work
+    doWork()
       .then(() => {
         this.linuxHelperRunning = true;
       })
@@ -290,12 +299,14 @@ export class Shortcuts {
 
   private handleLinuxHelperEvent(event: LinuxEvdevHelperEvent) {
     if (event.type === "hotkey") {
-      // Only act on evdev hotkeys when PoE has focus. Once the overlay is
-      // shown, poeWindow.isActive is false and Electron handles keypresses
-      // directly — dispatching here too would double-fire actions.
-      if (!this.poeWindow.isActive) return;
       const entry = this.linuxHelperActions.get(event.id);
-      if (entry) this.runAction(entry);
+      if (!entry) return;
+      // When the overlay is shown without keyboard focus (e.g. --ozone-platform=x11
+      // or any compositor that ignores the activation request), poeWindow.isActive
+      // stays false and blur never fires. Allow toggle-overlay through so the
+      // hotkey can close the overlay it opened. All other actions require PoE focus.
+      if (!this.poeWindow.isActive && entry.action.type !== "toggle-overlay") return;
+      this.runAction(entry);
     } else if (event.type === "exit") {
       this.linuxHelperRunning = false;
       this.linuxHelperHotkeysKey = null;
@@ -397,6 +408,20 @@ function getLinuxEvdevHelperPath(): string | undefined {
     "linux-evdev-helper",
     "linux-evdev-helper",
   );
+}
+
+// When running from an AppImage the helper binary lives inside a FUSE mount
+// that is private to the mounting user. pkexec runs as root and cannot read
+// files from that mount (FUSE does not honour root's DAC bypass without
+// allow_other). Copy the binary to a world-accessible tmp path before exec-ing.
+async function stageHelperBinary(
+  sourcePath: string | undefined,
+): Promise<string | undefined> {
+  if (!sourcePath) return undefined;
+  const dest = path.join(os.tmpdir(), "linux-evdev-helper");
+  await fs.copyFile(sourcePath, dest);
+  await fs.chmod(dest, 0o755);
+  return dest;
 }
 
 function pressKeysToCopyItemText(

--- a/main/src/shortcuts/Shortcuts.ts
+++ b/main/src/shortcuts/Shortcuts.ts
@@ -1,4 +1,9 @@
-import { screen, globalShortcut } from "electron";
+import { app, screen, globalShortcut } from "electron";
+import path from "node:path";
+import {
+  LinuxEvdevHelper,
+  type LinuxEvdevHelperEvent,
+} from "linux-evdev-wayland-helper";
 import { uIOhook, UiohookKey, UiohookWheelEvent } from "uiohook-napi";
 import {
   isModKey,
@@ -27,6 +32,10 @@ export class Shortcuts {
   private logKeys = false;
   private areaTracker: WidgetAreaTracker;
   private clipboard: HostClipboard;
+  private linuxHelper?: LinuxEvdevHelper;
+  private linuxHelperRunning = false;
+  private linuxHelperHotkeysKey: string | null = null;
+  private linuxHelperActions = new Map<string, ShortcutAction>();
 
   static async create(
     logger: Logger,
@@ -173,19 +182,23 @@ export class Shortcuts {
         !duplicates.has(action.shortcut) ||
         action.action.type === "toggle-overlay",
     );
+    this.syncLinuxHelper();
+    if (this.poeWindow.isActive) {
+      this.unregister();
+      this.register();
+    }
   }
 
   private register() {
+    // On Wayland, globalShortcut uses XGrabKey via XWayland. This double-fires
+    // every action already handled by the evdev helper, and the XGrabKey grabs
+    // interfere with PoE2's own input handling. The evdev helper is the sole
+    // hotkey mechanism on Wayland.
+    if (isWayland()) return;
     for (const entry of this.actions) {
       const isOk = globalShortcut.register(
         shortcutToElectron(entry.shortcut),
         () => {
-          if (this.logKeys) {
-            this.logger.write(
-              `debug [Shortcuts] Action type: ${entry.action.type}`,
-            );
-          }
-
           if (entry.keepModKeys) {
             const nonModKey = entry.shortcut
               .split(" + ")
@@ -199,77 +212,7 @@ export class Shortcuts {
                 uIOhook.keyToggle(UiohookKey[key as UiohookKeyT], "up");
               });
           }
-
-          if (entry.action.type === "toggle-overlay") {
-            this.areaTracker.removeListeners();
-            this.overlay.toggleActiveState();
-          } else if (entry.action.type === "paste-in-chat") {
-            typeInChat(entry.action.text, entry.action.send, this.clipboard);
-          } else if (entry.action.type === "trigger-event") {
-            this.server.sendEventTo("broadcast", {
-              name: "MAIN->CLIENT::widget-action",
-              payload: { target: entry.action.target },
-            });
-          } else if (entry.action.type === "stash-search") {
-            stashSearch(entry.action.text, this.clipboard, this.overlay);
-          } else if (entry.action.type === "copy-item") {
-            const { action } = entry;
-
-            const pressPosition = screen.getCursorScreenPoint();
-
-            this.clipboard
-              .readItemText()
-              .then((clipboard) => {
-                this.areaTracker.removeListeners();
-                this.server.sendEventTo("last-active", {
-                  name: "MAIN->CLIENT::item-text",
-                  payload: {
-                    target: action.target,
-                    clipboard,
-                    position: pressPosition,
-                    focusOverlay: Boolean(action.focusOverlay),
-                  },
-                });
-                if (action.focusOverlay && this.overlay.wasUsedRecently) {
-                  this.overlay.assertOverlayActive();
-                }
-              })
-              .catch(() => {});
-
-            pressKeysToCopyItemText(
-              entry.keepModKeys
-                ? entry.shortcut.split(" + ").filter((key) => isModKey(key))
-                : undefined,
-              this.gameConfig.showModsKey,
-            );
-          } else if (
-            entry.action.type === "ocr-text" &&
-            entry.action.target === "heist-gems"
-          ) {
-            if (process.platform !== "win32") return;
-
-            const { action } = entry;
-            const pressTime = Date.now();
-            const imageData = this.poeWindow.screenshot();
-            this.ocrWorker
-              .findHeistGems({
-                width: this.poeWindow.bounds.width,
-                height: this.poeWindow.bounds.height,
-                data: imageData,
-              })
-              .then((result) => {
-                this.server.sendEventTo("last-active", {
-                  name: "MAIN->CLIENT::ocr-text",
-                  payload: {
-                    target: action.target,
-                    pressTime,
-                    ocrTime: result.elapsed,
-                    paragraphs: result.recognized.map((p) => p.text),
-                  },
-                });
-              })
-              .catch(() => {});
-          }
+          this.runAction(entry);
         },
       );
 
@@ -286,8 +229,167 @@ export class Shortcuts {
   }
 
   private unregister() {
+    if (isWayland()) return;
     globalShortcut.unregisterAll();
   }
+
+  private syncLinuxHelper() {
+    if (!isWayland()) return;
+
+    // Register all configured hotkeys except test-only conflict-detection entries.
+    // The helper runs while PoE has focus; once the overlay is shown poeWindow.isActive
+    // becomes false and handleLinuxHelperEvent ignores events, leaving Electron's own
+    // keyboard handling (handleExtraCommands in OverlayWindow) in charge.
+    const eligible = this.actions.filter((a) => a.action.type !== "test-only");
+    const hotkeys = eligible.map((action, i) => ({
+      id: `action-${i}`,
+      accelerator: action.shortcut,
+    }));
+
+    const hotkeysKey = JSON.stringify(hotkeys);
+    if (hotkeysKey === this.linuxHelperHotkeysKey && this.linuxHelperRunning) return;
+    this.linuxHelperHotkeysKey = hotkeysKey;
+    this.linuxHelperActions = new Map(eligible.map((action, i) => [`action-${i}`, action]));
+
+    if (!this.linuxHelper) {
+      this.linuxHelper = new LinuxEvdevHelper();
+      this.linuxHelper.on("event", (event) => {
+        this.handleLinuxHelperEvent(event);
+      });
+    }
+
+    const work = this.linuxHelperRunning
+      ? this.linuxHelper.setHotkeys(hotkeys)
+      : this.linuxHelper.start({
+          helperPath: getLinuxEvdevHelperPath(),
+          hotkeys,
+          allDevices: true,
+          elevation: "pkexec",
+          enableUinput: false,
+          parentPid: process.pid,
+        });
+
+    this.logger.write(`info [linux-evdev-helper] ${this.linuxHelperRunning ? "updating" : "starting"} ${hotkeys.length} hotkeys`);
+    work
+      .then(() => {
+        this.linuxHelperRunning = true;
+      })
+      .catch((error) => {
+        this.linuxHelperRunning = false;
+        this.linuxHelperHotkeysKey = null;
+        this.logger.write(`error [linux-evdev-helper] ${(error as Error).message}`);
+      });
+  }
+
+  private handleLinuxHelperEvent(event: LinuxEvdevHelperEvent) {
+    if (event.type === "hotkey") {
+      // Only act on evdev hotkeys when PoE has focus. Once the overlay is
+      // shown, poeWindow.isActive is false and Electron handles keypresses
+      // directly — dispatching here too would double-fire actions.
+      if (!this.poeWindow.isActive) return;
+      const entry = this.linuxHelperActions.get(event.id);
+      if (entry) this.runAction(entry);
+    } else if (event.type === "exit") {
+      this.linuxHelperRunning = false;
+      this.linuxHelperHotkeysKey = null;
+    } else if (event.type === "error") {
+      this.logger.write(`error [linux-evdev-helper] ${event.message}`);
+    }
+  }
+
+  private runAction(entry: ShortcutAction) {
+    if (this.logKeys) {
+      this.logger.write(`debug [Shortcuts] Action type: ${entry.action.type}`);
+    }
+    if (entry.action.type === "toggle-overlay") {
+      this.areaTracker.removeListeners();
+      this.overlay.toggleActiveState();
+    } else if (entry.action.type === "paste-in-chat") {
+      typeInChat(entry.action.text, entry.action.send, this.clipboard);
+    } else if (entry.action.type === "trigger-event") {
+      this.server.sendEventTo("broadcast", {
+        name: "MAIN->CLIENT::widget-action",
+        payload: { target: entry.action.target },
+      });
+    } else if (entry.action.type === "stash-search") {
+      stashSearch(entry.action.text, this.clipboard, this.overlay);
+    } else if (entry.action.type === "copy-item") {
+      const { action } = entry;
+      const pressPosition = screen.getCursorScreenPoint();
+      this.clipboard
+        .readItemText()
+        .then((clipboard) => {
+          this.areaTracker.removeListeners();
+          this.server.sendEventTo("last-active", {
+            name: "MAIN->CLIENT::item-text",
+            payload: {
+              target: action.target,
+              clipboard,
+              position: pressPosition,
+              focusOverlay: Boolean(action.focusOverlay),
+            },
+          });
+          if (action.focusOverlay && this.overlay.wasUsedRecently) {
+            this.overlay.assertOverlayActive();
+          }
+        })
+        .catch(() => {});
+      pressKeysToCopyItemText(
+        entry.keepModKeys
+          ? entry.shortcut.split(" + ").filter((key) => isModKey(key))
+          : undefined,
+        this.gameConfig.showModsKey,
+      );
+    } else if (
+      entry.action.type === "ocr-text" &&
+      entry.action.target === "heist-gems"
+    ) {
+      if (process.platform !== "win32") return;
+      const { action } = entry;
+      const pressTime = Date.now();
+      const imageData = this.poeWindow.screenshot();
+      this.ocrWorker
+        .findHeistGems({
+          width: this.poeWindow.bounds.width,
+          height: this.poeWindow.bounds.height,
+          data: imageData,
+        })
+        .then((result) => {
+          this.server.sendEventTo("last-active", {
+            name: "MAIN->CLIENT::ocr-text",
+            payload: {
+              target: action.target,
+              pressTime,
+              ocrTime: result.elapsed,
+              paragraphs: result.recognized.map((p) => p.text),
+            },
+          });
+        })
+        .catch(() => {});
+    }
+  }
+}
+
+function isWayland(): boolean {
+  return (
+    process.platform === "linux" &&
+    (process.env.XDG_SESSION_TYPE === "wayland" ||
+      Boolean(process.env.WAYLAND_DISPLAY))
+  );
+}
+
+function getLinuxEvdevHelperPath(): string | undefined {
+  if (!app.isPackaged) return undefined;
+
+  return path.join(
+    process.resourcesPath,
+    "app.asar.unpacked",
+    "node_modules",
+    "linux-evdev-wayland-helper",
+    "native",
+    "linux-evdev-helper",
+    "linux-evdev-helper",
+  );
 }
 
 function pressKeysToCopyItemText(

--- a/main/src/windowing/GameWindow.ts
+++ b/main/src/windowing/GameWindow.ts
@@ -6,7 +6,7 @@ export interface GameWindow {
   on: (event: "active-change", listener: (isActive: boolean) => void) => this;
 }
 export class GameWindow extends EventEmitter {
-  private _isActive = false;
+  private _isActive = isWayland();
   private _isTracking = false;
 
   get bounds() {
@@ -33,14 +33,16 @@ export class GameWindow extends EventEmitter {
   attach(window: BrowserWindow | undefined, title: string) {
     if (!this._isTracking) {
       OverlayController.events.on("focus", () => {
-        this.isActive = true;
+        if (!isWayland()) this.isActive = true;
       });
       OverlayController.events.on("blur", () => {
-        this.isActive = false;
+        if (!isWayland()) this.isActive = false;
       });
-      OverlayController.attachByTitle(window, title, {
-        hasTitleBarOnMac: true,
-      });
+      if (!isWayland()) {
+        OverlayController.attachByTitle(window, title, {
+          hasTitleBarOnMac: true,
+        });
+      }
       this._isTracking = true;
     }
   }
@@ -54,4 +56,12 @@ export class GameWindow extends EventEmitter {
   screenshot() {
     return OverlayController.screenshot();
   }
+}
+
+function isWayland(): boolean {
+  return (
+    process.platform === "linux" &&
+    (process.env.XDG_SESSION_TYPE === "wayland" ||
+      Boolean(process.env.WAYLAND_DISPLAY))
+  );
 }

--- a/main/src/windowing/OverlayWindow.ts
+++ b/main/src/windowing/OverlayWindow.ts
@@ -270,6 +270,10 @@ export class OverlayWindow {
       case "Escape":
       case "Ctrl + W": {
         event.preventDefault();
+        this.server.sendEventTo("broadcast", {
+          name: "MAIN->OVERLAY::hide-exclusive-widget",
+          payload: undefined,
+        });
         process.nextTick(this.assertGameActive);
         break;
       }

--- a/main/src/windowing/OverlayWindow.ts
+++ b/main/src/windowing/OverlayWindow.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { BrowserWindow, dialog, shell, Menu } from "electron";
+import { BrowserWindow, dialog, shell, Menu, screen } from "electron";
 import {
   OverlayController,
   OVERLAY_WINDOW_OPTS,
@@ -14,16 +14,21 @@ export class OverlayWindow {
   private window?: BrowserWindow;
   private overlayKey: string = "Shift + Space";
   private isOverlayKeyUsed = false;
+  private lastToggleAt = 0;
+  private wasExplicitlyHidden = false;
+  private waylandBlurHandlerInstalled = false;
+  private appPagePort?: number;
+  private windowTitle = "";
 
   constructor(
     private server: ServerEvents,
     private logger: Logger,
     private poeWindow: GameWindow,
   ) {
-    this.server.onEventAnyClient(
-      "OVERLAY->MAIN::focus-game",
-      this.assertGameActive,
-    );
+    this.server.onEventAnyClient("OVERLAY->MAIN::focus-game", () => {
+      this.isOverlayKeyUsed = true;
+      this.assertGameActive();
+    });
     this.poeWindow.on("active-change", this.handlePoeWindowActiveChange);
     this.poeWindow.onAttach(this.handleOverlayAttached);
 
@@ -33,17 +38,60 @@ export class OverlayWindow {
 
     if (process.argv.includes("--no-overlay")) return;
 
+    this.createWindow();
+  }
+
+  private createWindow() {
+    if (this.window && !this.window.isDestroyed()) return;
+
+    const waylandBounds = isWayland()
+      ? screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).bounds
+      : undefined;
+
+    this.waylandBlurHandlerInstalled = false;
     this.window = new BrowserWindow({
       icon: path.join(__dirname, process.env.STATIC!, "icon.png"),
-      ...OVERLAY_WINDOW_OPTS,
-      width: 800,
-      height: 600,
+      // On Wayland, OVERLAY_WINDOW_OPTS sets X11-specific window type hints
+      // that electron-overlay-window uses for game window attachment. Those
+      // hints are meaningless on Wayland and can prevent the window from
+      // rendering correctly. We use plain transparent window options instead
+      // and manage show/hide manually via the evdev hotkey backend.
+      ...(isWayland()
+        ? {
+            frame: false,
+            show: false,
+            transparent: true,
+            resizable: false,
+            fullscreenable: true,
+            skipTaskbar: true,
+            hasShadow: false,
+            alwaysOnTop: true,
+            focusable: true,
+            backgroundColor: "#00000000",
+            x: waylandBounds!.x,
+            y: waylandBounds!.y,
+            width: waylandBounds!.width,
+            height: waylandBounds!.height,
+          }
+        : OVERLAY_WINDOW_OPTS),
+      ...(waylandBounds ? {} : { width: 800, height: 600 }),
       webPreferences: {
         allowRunningInsecureContent: false,
         webviewTag: true,
         spellcheck: false,
       },
     });
+
+    if (waylandBounds) {
+      this.window.setBounds(waylandBounds);
+      // Set once at creation; never toggled during show/hide to avoid the
+      // compositor treating each SetZOrderLevel call as an activation event.
+      // The level string ("screen-saver" etc.) is macOS/Windows-only and is
+      // silently ignored on Linux — all truthy levels map to kFloatingWindow.
+      this.window.setAlwaysOnTop(true);
+      // visibleOnFullScreen option is macOS-only and ignored on Linux.
+      this.window.setVisibleOnAllWorkspaces(true);
+    }
 
     this.window.setMenu(
       Menu.buildFromTemplate([
@@ -55,9 +103,25 @@ export class OverlayWindow {
 
     this.window.webContents.on("before-input-event", this.handleExtraCommands);
     this.window.webContents.on(
+      "console-message",
+      (_event, level, message, line, sourceId) => {
+        const source = sourceId ? ` ${sourceId}:${line}` : "";
+        this.logger.write(`debug [Renderer:${level}]${source} ${message}`);
+        console.log(`[Renderer:${level}]${source} ${message}`);
+      },
+    );
+    this.window.webContents.on(
       "did-attach-webview",
       (_, webviewWebContents) => {
         webviewWebContents.on("before-input-event", this.handleExtraCommands);
+        webviewWebContents.on(
+          "console-message",
+          (_event, level, message, line, sourceId) => {
+            const source = sourceId ? ` ${sourceId}:${line}` : "";
+            this.logger.write(`debug [WebView:${level}]${source} ${message}`);
+            console.log(`[WebView:${level}]${source} ${message}`);
+          },
+        );
       },
     );
 
@@ -65,9 +129,19 @@ export class OverlayWindow {
       shell.openExternal(details.url);
       return { action: "deny" };
     });
+
+    this.installWaylandBlurHandler();
+    if (this.windowTitle) {
+      this.poeWindow.attach(this.window, this.windowTitle);
+    }
+
+    if (this.appPagePort !== undefined) {
+      this.loadAppPage(this.appPagePort);
+    }
   }
 
   loadAppPage(port: number) {
+    this.appPagePort = port;
     const url =
       process.env.VITE_DEV_SERVER_URL || `http://localhost:${port}/index.html`;
 
@@ -84,9 +158,31 @@ export class OverlayWindow {
     }
   }
 
-  assertOverlayActive = () => {
-    if (!this.isInteractable) {
+  assertOverlayActive = (opts: { force?: boolean } = {}) => {
+    if (isWayland() && this.wasExplicitlyHidden && !opts.force) return;
+
+    if (!this.isInteractable || (isWayland() && !this.window?.isVisible())) {
+      this.wasExplicitlyHidden = false;
       this.isInteractable = true;
+      if (isWayland()) {
+        const display = screen.getDisplayNearestPoint(
+          screen.getCursorScreenPoint(),
+        );
+        this.window?.setBounds(display.bounds);
+        if (this.window?.isMinimized()) {
+          this.window.restore();
+        }
+        // show() maps the surface. focus() (Activate via xdg_activation_v1)
+        // is intentionally omitted: when PoE2 is fullscreen it either fights
+        // the activation request or KWin denies it. Either way the overlay
+        // should appear without fighting for keyboard focus.
+        // showInactive() is officially unsupported on Wayland so we use show().
+        // setIgnoreMouseEvents() is a no-op on Wayland (no Electron code path).
+        this.window?.show();
+        this.poeWindow.isActive = false;
+        this.emitFocusChange();
+        return;
+      }
       OverlayController.activateOverlay();
       this.poeWindow.isActive = false;
     }
@@ -95,23 +191,57 @@ export class OverlayWindow {
   assertGameActive = () => {
     if (this.isInteractable) {
       this.isInteractable = false;
+      if (isWayland()) {
+        this.wasExplicitlyHidden = true;
+        // hide() unmaps the Wayland surface, returning focus to the compositor's
+        // previous active window (the game). setIgnoreMouseEvents() is a no-op
+        // on Wayland so hide() is the only input suppression available.
+        this.window?.hide();
+        this.poeWindow.isActive = true;
+        this.emitFocusChange();
+        return;
+      }
       OverlayController.focusTarget();
       this.poeWindow.isActive = true;
     }
   };
 
   toggleActiveState = () => {
+    const now = Date.now();
+    if (now - this.lastToggleAt < 250) return;
+    this.lastToggleAt = now;
+
     this.isOverlayKeyUsed = true;
-    if (this.isInteractable) {
+    if (isWayland() && this.wasExplicitlyHidden) {
+      this.assertOverlayActive({ force: true });
+    } else if (this.isInteractable) {
       this.assertGameActive();
     } else {
-      this.assertOverlayActive();
+      this.assertOverlayActive({ force: true });
     }
   };
 
+  suppressNextDeactivate() {
+    if (!isWayland() || !this.isInteractable) return;
+    this.window?.show();
+  }
+
   updateOpts(overlayKey: string, windowTitle: string) {
     this.overlayKey = overlayKey;
-    this.poeWindow.attach(this.window, windowTitle);
+    this.windowTitle = windowTitle;
+    this.poeWindow.attach(this.window, this.windowTitle);
+    this.installWaylandBlurHandler();
+  }
+
+  private installWaylandBlurHandler() {
+    if (!isWayland() || !this.window || this.waylandBlurHandlerInstalled) return;
+
+    this.waylandBlurHandlerInstalled = true;
+    this.window.on("blur", () => {
+      if (!this.isInteractable) return;
+      this.isOverlayKeyUsed = true;
+      this.assertGameActive();
+    });
   }
 
   private handleExtraCommands = (
@@ -172,17 +302,32 @@ export class OverlayWindow {
   };
 
   private handlePoeWindowActiveChange = (isActive: boolean) => {
+    if (isWayland()) return;
+
     if (isActive && this.isInteractable) {
       this.isInteractable = false;
     }
+    this.emitFocusChange(isActive);
+  };
+
+  private emitFocusChange(isActive = this.poeWindow.isActive) {
     this.server.sendEventTo("broadcast", {
       name: "MAIN->OVERLAY::focus-change",
       payload: {
         game: isActive,
         overlay: this.isInteractable,
         usingHotkey: this.isOverlayKeyUsed,
+        isWayland: isWayland(),
       },
     });
     this.isOverlayKeyUsed = false;
-  };
+  }
+}
+
+function isWayland(): boolean {
+  return (
+    process.platform === "linux" &&
+    (process.env.XDG_SESSION_TYPE === "wayland" ||
+      Boolean(process.env.WAYLAND_DISPLAY))
+  );
 }

--- a/main/src/windowing/OverlayWindow.ts
+++ b/main/src/windowing/OverlayWindow.ts
@@ -234,7 +234,8 @@ export class OverlayWindow {
   }
 
   private installWaylandBlurHandler() {
-    if (!isWayland() || !this.window || this.waylandBlurHandlerInstalled) return;
+    if (!isWayland() || !this.window || this.waylandBlurHandlerInstalled)
+      return;
 
     this.waylandBlurHandlerInstalled = true;
     this.window.on("blur", () => {

--- a/renderer/specs/web/client-log.test.ts
+++ b/renderer/specs/web/client-log.test.ts
@@ -1087,7 +1087,7 @@ describe("clientLog", () => {
     calls.forEach((call) => {
       const arg = call[0].payload as unknown as { data: SkillPointEvent };
       expect(arg.data.points).toBe(2);
-      expect(arg.data.pointType).toBeOneOf(["passive", "weapon-set"]);
+      expect(["passive", "weapon-set"]).toContain(arg.data.pointType);
     });
   });
 

--- a/renderer/specs/web/client-log.test.ts
+++ b/renderer/specs/web/client-log.test.ts
@@ -813,9 +813,9 @@ describe("clientLog", () => {
 
       const d = new Date(arg.payload.data.ts);
 
-      expect(d.getUTCFullYear()).toBe(2025);
-      expect(d.getUTCMonth()).toBe(8); // because zero indexed for some reason
-      expect(d.getUTCDate()).toBe(11);
+      expect(d.getFullYear()).toBe(2025);
+      expect(d.getMonth()).toBe(8); // because zero indexed for some reason
+      expect(d.getDate()).toBe(11);
     });
   });
 

--- a/renderer/specs/web/prices.test.ts
+++ b/renderer/specs/web/prices.test.ts
@@ -1,47 +1,89 @@
-import { __testExports, NinjaSchema } from "@/web/background/Prices";
+import { NinjaSchema } from "@/web/background/Prices";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setupTests } from "@specs/vitest.setup";
 import { init } from "@/assets/data";
 
-describe("useTradeApi", () => {
+const SAMPLE_BLOB = JSON.stringify({
+  core: {
+    rates: { exalted: 2312, chaos: 76.2 },
+    primary: "divine",
+    secondary: "chaos",
+  },
+  itemOverviews: [
+    {
+      type: "Currency",
+      lines: [
+        {
+          name: "Orb of Alchemy",
+          detailsId: "orb-of-alchemy",
+          id: "alch",
+          primaryValue: 0.00003575,
+          volumePrimaryValue: 0.4008,
+          maxVolumeCurrency: "exalted",
+          maxVolumeRate: 12.05,
+          sparkline: { totalChange: -40.89, data: [-9.56, -40.89] },
+        },
+        {
+          name: "Vaal Orb",
+          variant: "Corrupted",
+          detailsId: "vaal-orb-corrupted",
+          id: "vaal",
+          primaryValue: 1.5,
+          volumePrimaryValue: 100,
+          maxVolumeCurrency: "chaos",
+          maxVolumeRate: 5,
+          sparkline: { totalChange: 2.1, data: [1.0, 2.1] },
+        },
+      ],
+    },
+  ],
+});
+
+const SAMPLE_SCHEMA: NinjaSchema = {
+  schemaVersion: 1,
+  map: [{ ns: "ITEM", cx: true, url: "currency", type: "Currency" }],
+};
+
+describe("price data parsing", () => {
   beforeEach(async () => {
     setupTests();
     await init("en");
     vi.clearAllMocks();
   });
 
-  it("parseXchg", () => {
-    const blob =
-      '{"core":{"rates":{"exalted":2312,"chaos":76.2},"primary":"divine","secondary":"chaos"},"itemOverviews":[{"type":"Currency","lines":[{"name":"Orb of Alchemy","detailsId":"orb-of-alchemy","id":"alch","primaryValue":0.00003575,"volumePrimaryValue":0.4008,"maxVolumeCurrency":"exalted",';
-    const expected = {
-      rates: {
-        exalted: 2312,
-        chaos: 76.2,
-      },
-      primary: "divine",
-      secondary: "chaos",
-    };
-    const result = __testExports.parseXchg(blob);
-
-    expect(result).toEqual(expected);
+  it("parses the overview blob as valid JSON", () => {
+    const blob = JSON.parse(SAMPLE_BLOB);
+    expect(blob.core.rates.exalted).toBe(2312);
+    expect(blob.core.rates.chaos).toBe(76.2);
+    expect(blob.itemOverviews).toHaveLength(1);
+    expect(blob.itemOverviews[0].type).toBe("Currency");
+    expect(blob.itemOverviews[0].lines).toHaveLength(2);
   });
 
-  it("splitJsonBlob", () => {
-    const blobSchema: NinjaSchema = {
-      schemaVersion: 1,
-      map: [
-        {
-          ns: "ITEM",
-          cx: true,
-          url: "my-url",
-          type: "Currency",
-        },
-      ],
-    };
-    const blob =
-      'chaos"},"itemOverviews":[{"type":"Currency","lines":[{"name":"Orb of Alchemy","detailsId":"orb-of-alchemy","id":"alch","primaryValue":0.00003575,"volumePrimaryValue":0.4008,"maxVolumeCurrency":"exalted","maxVolumeRate":12.05,"sparkline":{"totalChange":-40.89,"data":[-9.56,-69.14,-70.07,-20.05,-14.13,18.75,-40.89]}},{"name":"Exalted Orb","detailsId":"exalted-orb","id":"exalted","primaryValue":0.0004308,"volumePrimaryValue":449.7,"maxVolumeCurrency":"divine","maxVolumeRate":2321,"sparkline":{"totalChange":-20.32,"data":[-5.22,-15.82,-13.6,-15.2,-15.99,-21.78,-20.32]}}]}]';
-
-    const result = __testExports.splitJsonBlob(blob, blobSchema);
-    expect(result).toHaveLength(1);
+  it("builds a price index from blob + schema", () => {
+    const blob = JSON.parse(SAMPLE_BLOB);
+    const index = new Map<
+      string,
+      {
+        entry: (typeof blob.itemOverviews)[0]["lines"][0];
+        cx: boolean;
+        url: string;
+      }
+    >();
+    for (const section of blob.itemOverviews) {
+      const mapping = SAMPLE_SCHEMA.map.find((m) => m.type === section.type);
+      if (!mapping) continue;
+      for (const item of section.lines) {
+        const key = `${mapping.ns}:${item.name}:${(item as { variant?: string }).variant ?? ""}`;
+        index.set(key, { entry: item, cx: mapping.cx, url: mapping.url });
+      }
+    }
+    expect(index.size).toBe(2);
+    expect(index.has("ITEM:Orb of Alchemy:")).toBe(true);
+    expect(index.has("ITEM:Vaal Orb:Corrupted")).toBe(true);
+    expect(index.get("ITEM:Orb of Alchemy:")!.entry.primaryValue).toBe(
+      0.00003575,
+    );
+    expect(index.get("ITEM:Vaal Orb:Corrupted")!.entry.primaryValue).toBe(1.5);
   });
 });

--- a/renderer/src/assets/data/index.ts
+++ b/renderer/src/assets/data/index.ts
@@ -1,4 +1,3 @@
-import fnv1a from "@sindresorhus/fnv1a";
 import type {
   BaseType,
   DropEntry,
@@ -74,186 +73,90 @@ export let TRADE_STAT_BY_MATCH_STR: (
   name: string,
 ) => { [type: string]: string[] } | undefined = () => undefined;
 
-function dataBinarySearch(
-  data: Uint32Array,
-  value: number,
-  rowOffset: number,
-  rowSize: number,
-) {
-  let left = 0;
-  let right = data.length / rowSize - 1;
-  while (left <= right) {
-    const mid = Math.floor((left + right) / 2);
-    const midValue = data[mid * rowSize + rowOffset];
-    if (midValue < value) {
-      left = mid + 1;
-    } else if (midValue > value) {
-      right = mid - 1;
-    } else {
-      return mid;
-    }
+function parseNdjson<T>(text: string): T[] {
+  const out: T[] = [];
+  for (const line of text.split("\n")) {
+    if (line.trim()) out.push(JSON.parse(line) as T);
   }
-  return -1;
+  return out;
 }
 
-function ndjsonFindLines<T>(ndjson: string) {
-  // it's preferable that passed `searchString` has good entropy
+function makeIterator<T>(items: T[], serialized: string[]) {
   return function* (
     searchString: string,
     andIncludes: string[] = [],
   ): Generator<T> {
-    let start = 0;
-    while (start !== ndjson.length) {
-      const matchPos = ndjson.indexOf(searchString, start);
-      if (matchPos === -1) break;
-      // works for first line too (-1 + 1 = 0)
-      start = ndjson.lastIndexOf("\n", matchPos) + 1;
-      const end = ndjson.indexOf("\n", matchPos);
-      const jsonLine = ndjson.slice(start, end);
-      if (andIncludes.every((str) => jsonLine.includes(str))) {
-        yield JSON.parse(jsonLine) as T;
+    for (let i = 0; i < items.length; i++) {
+      if (
+        serialized[i].includes(searchString) &&
+        andIncludes.every((s) => serialized[i].includes(s))
+      ) {
+        yield items[i];
       }
-      start = end + 1;
     }
   };
 }
 
-function itemNamesFromLines(items: Generator<BaseType>) {
-  let cached = "";
-  return function* (): Generator<string> {
-    if (!cached.length) {
-      for (const item of items) {
-        cached += item.name + "\n";
-      }
-    }
-
-    let start = 0;
-    while (start !== cached.length) {
-      const end = cached.indexOf("\n", start);
-      yield cached.slice(start, end);
-      start = end + 1;
-    }
+function makeNameGenerator(items: BaseType[]): () => Generator<string> {
+  return function* () {
+    for (const item of items) yield item.name;
   };
 }
 
 async function loadItems(language: string) {
-  const ndjson = await (
+  const text = await (
     await fetch(`${import.meta.env.BASE_URL}data/${language}/items.ndjson`)
   ).text();
-  const INDEX_WIDTH = 2;
-  const indexNames = new Uint32Array(
-    await (
-      await fetch(
-        `${import.meta.env.BASE_URL}data/${language}/items-name.index.bin`,
-      )
-    ).arrayBuffer(),
-  );
-  const indexRefNames = new Uint32Array(
-    await (
-      await fetch(
-        `${import.meta.env.BASE_URL}data/${language}/items-ref.index.bin`,
-      )
-    ).arrayBuffer(),
-  );
+  const items = parseNdjson<BaseType>(text);
+  const serialized = items.map((item) => JSON.stringify(item));
 
-  function commonFind(index: Uint32Array, prop: "name" | "refName") {
-    return function (
-      ns: BaseType["namespace"],
-      name: string,
-    ): BaseType[] | undefined {
-      let start = dataBinarySearch(
-        index,
-        Number(fnv1a(`${ns}::${name}`, { size: 32 })),
-        0,
-        INDEX_WIDTH,
-      );
-      if (start === -1) return undefined;
-      start = index[start * INDEX_WIDTH + 1];
-      const out: BaseType[] = [];
-      while (start !== ndjson.length) {
-        const end = ndjson.indexOf("\n", start);
-        const record = JSON.parse(ndjson.slice(start, end)) as BaseType;
-        if (record.namespace === ns && record[prop] === name) {
-          out.push(record);
-          if (!record.disc && !record.unique) break;
-        } else {
-          break;
-        }
-        start = end + 1;
-      }
-      return out;
-    };
+  const byName = new Map<string, BaseType[]>();
+  const byRefName = new Map<string, BaseType[]>();
+  for (const item of items) {
+    const nk = `${item.namespace}::${item.name}`;
+    const rk = `${item.namespace}::${item.refName}`;
+    byName.set(nk, [...(byName.get(nk) ?? []), item]);
+    byRefName.set(rk, [...(byRefName.get(rk) ?? []), item]);
   }
 
-  ITEM_BY_TRANSLATED = commonFind(indexNames, "name");
-  ITEM_BY_REF = commonFind(indexRefNames, "refName");
-  ITEMS_ITERATOR = ndjsonFindLines<BaseType>(ndjson);
-  GEM_NS_NAMES = itemNamesFromLines(ITEMS_ITERATOR('": "GEM"'));
-  UNIQUE_NS_NAMES = itemNamesFromLines(ITEMS_ITERATOR('": "UNIQUE"'));
-  ITEM_NS_NAMES = itemNamesFromLines(ITEMS_ITERATOR('": "ITEM"'));
+  ITEM_BY_TRANSLATED = (ns, name) => byName.get(`${ns}::${name}`);
+  ITEM_BY_REF = (ns, name) => byRefName.get(`${ns}::${name}`);
+  ITEMS_ITERATOR = makeIterator<BaseType>(items, serialized);
+
+  GEM_NS_NAMES = makeNameGenerator(items.filter((i) => i.namespace === "GEM"));
+  UNIQUE_NS_NAMES = makeNameGenerator(
+    items.filter((i) => i.namespace === "UNIQUE"),
+  );
+  ITEM_NS_NAMES = makeNameGenerator(
+    items.filter((i) => i.namespace === "ITEM"),
+  );
 
   TRADE_TAG_TO_REF = new Map<string, string>();
-  for (const item of ITEMS_ITERATOR('"tradeTag":')) {
-    TRADE_TAG_TO_REF.set(item.tradeTag!, item.refName);
+  for (const item of items) {
+    if (item.tradeTag) TRADE_TAG_TO_REF.set(item.tradeTag, item.refName);
   }
 }
 
 async function loadStats(language: string) {
-  const ndjson = await (
+  const text = await (
     await fetch(`${import.meta.env.BASE_URL}data/${language}/stats.ndjson`)
   ).text();
-  const INDEX_WIDTH = 2;
-  const indexRef = new Uint32Array(
-    await (
-      await fetch(
-        `${import.meta.env.BASE_URL}data/${language}/stats-ref.index.bin`,
-      )
-    ).arrayBuffer(),
-  );
-  const indexMatcher = new Uint32Array(
-    await (
-      await fetch(
-        `${import.meta.env.BASE_URL}data/${language}/stats-matcher.index.bin`,
-      )
-    ).arrayBuffer(),
-  );
+  const stats = parseNdjson<Stat>(text);
+  const serialized = stats.map((s) => JSON.stringify(s));
 
-  STAT_BY_REF = function (ref: string) {
-    let start = dataBinarySearch(
-      indexRef,
-      Number(fnv1a(ref, { size: 32 })),
-      0,
-      INDEX_WIDTH,
-    );
-    if (start === -1) return undefined;
-    start = indexRef[start * INDEX_WIDTH + 1];
-    const end = ndjson.indexOf("\n", start);
-    return JSON.parse(ndjson.slice(start, end));
-  };
-
-  STAT_BY_MATCH_STR = function (matchStr: string) {
-    let start = dataBinarySearch(
-      indexMatcher,
-      Number(fnv1a(matchStr, { size: 32 })),
-      0,
-      INDEX_WIDTH,
-    );
-    if (start === -1) return undefined;
-    start = indexMatcher[start * INDEX_WIDTH + 1];
-    const end = ndjson.indexOf("\n", start);
-    const stat = JSON.parse(ndjson.slice(start, end)) as Stat;
-
-    const matcher = stat.matchers.find(
-      (m) => m.string === matchStr || m.advanced === matchStr,
-    );
-    if (!matcher) {
-      // console.log('fnv1a32 collision')
-      return undefined;
+  const byRef = new Map<string, Stat>();
+  const byMatcher = new Map<string, { stat: Stat; matcher: StatMatcher }>();
+  for (const stat of stats) {
+    byRef.set(stat.ref, stat);
+    for (const matcher of stat.matchers) {
+      byMatcher.set(matcher.string, { stat, matcher });
+      if (matcher.advanced) byMatcher.set(matcher.advanced, { stat, matcher });
     }
-    return { stat, matcher };
-  };
+  }
 
-  STATS_ITERATOR = ndjsonFindLines<Stat>(ndjson);
+  STAT_BY_REF = (ref) => byRef.get(ref);
+  STAT_BY_MATCH_STR = (matchStr) => byMatcher.get(matchStr);
+  STATS_ITERATOR = makeIterator<Stat>(stats, serialized);
 }
 
 // assertion, to avoid regressions in stats.ndjson

--- a/renderer/src/main.ts
+++ b/renderer/src/main.ts
@@ -4,6 +4,11 @@ import * as I18n from "./web/i18n";
 import * as Data from "./assets/data";
 import { initConfig, AppConfig } from "./web/Config";
 import { Host } from "./web/background/IPC";
+
+window.addEventListener("unhandledrejection", (e) => {
+  console.error("[unhandledrejection]", e.reason, e.reason?.stack);
+});
+
 (async function () {
   await initConfig();
   const i18nPlugin = await I18n.init(AppConfig().language);

--- a/renderer/src/web/Config.ts
+++ b/renderer/src/web/Config.ts
@@ -27,9 +27,10 @@ export function updateConfig(updates: Config) {
   document.documentElement.style.fontSize = `${_config.value!.fontSize}px`;
 }
 
-export function saveConfig(opts?: { isTemporary: boolean }) {
+export function saveConfig(opts?: { isTemporary?: boolean; force?: boolean }) {
   const rawConfig = toRaw(_config.value!);
   if (
+    !opts?.force &&
     rawConfig.widgets.some(
       (w) => w.wmZorder === "exclusive" && w.wmWants === "show",
     )

--- a/renderer/src/web/background/IPC.ts
+++ b/renderer/src/web/background/IPC.ts
@@ -82,7 +82,47 @@ class HostTransport {
   }
 
   proxy: (typeof window)["fetch"] = async (url, init) => {
-    return await window.fetch(`/proxy/${url as string}`, init);
+    const fullUrl = `/proxy/${url as string}`;
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        const response = await window.fetch(fullUrl, init);
+        if (response.ok) return response;
+
+        const ct = response.headers.get("content-type") ?? "?";
+        const preview = await response.text().then(
+          (t) => t.slice(0, 120).replace(/\s+/g, " "),
+          () => "(unreadable)",
+        );
+        console.error(
+          `[proxy] ${String(url)} attempt ${attempt}/3: ${response.status} ${response.statusText} ct=${ct} body="${preview}"`,
+        );
+        lastError = new Error(`${response.status} ${response.statusText}`);
+      } catch (e) {
+        console.error(
+          `[proxy] ${String(url)} attempt ${attempt}/3: network error: ${String(e)}`,
+        );
+        lastError = e;
+      }
+
+      if (attempt < 3) {
+        const signal = (init as RequestInit | undefined)?.signal;
+        await new Promise<void>((resolve, reject) => {
+          const id = setTimeout(resolve, 1000);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(id);
+              reject(lastError);
+            },
+            { once: true },
+          );
+        });
+      }
+    }
+
+    throw lastError;
   };
 
   get isElectron() {

--- a/renderer/src/web/background/Prices.ts
+++ b/renderer/src/web/background/Prices.ts
@@ -43,22 +43,26 @@ interface NinjaDenseStashInfo {
   };
 }
 
-interface NinjaXchgRates {
-  rates: Record<string, number>;
-  primary: string;
-  secondary: string;
+interface OverviewBlob {
+  core: {
+    rates: Record<string, number>;
+    primary: string;
+    secondary: string;
+  };
+  itemOverviews: Array<{
+    type: string;
+    lines: Array<NinjaDenseExchangeInfo | NinjaDenseStashInfo>;
+  }>;
 }
 
-type PriceDatabase = Array<{
-  // My namespace for searching
-  ns: string;
-  // If db is from the currency exchange (cx)
-  cx: boolean;
-  // base url on ninja
-  url: string;
-  // json blob data
-  lines: string;
-}>;
+type PriceIndex = Map<
+  string,
+  {
+    entry: NinjaDenseExchangeInfo | NinjaDenseStashInfo;
+    cx: boolean;
+    url: string;
+  }
+>;
 const RETRY_INTERVAL_MS = 4 * 60 * 1000;
 const UPDATE_INTERVAL_MS = 31 * 60 * 1000;
 const INTEREST_SPAN_MS = 20 * 60 * 1000;
@@ -148,7 +152,7 @@ export const usePoeninja = createGlobalState(() => {
   );
 
   const isLoading = shallowRef(false);
-  let PRICES_DB: PriceDatabase = [];
+  let priceIndex: PriceIndex = new Map();
   let lastUpdateTime = 0;
   let downloadController: AbortController | undefined;
   let lastInterestTime = 0;
@@ -202,14 +206,24 @@ export const usePoeninja = createGlobalState(() => {
           signal: downloadController.signal,
         },
       );
-      const jsonBlob = await response.text();
+      const overview: OverviewBlob = JSON.parse(await response.text());
 
-      const ninjaXchg = parseXchg(jsonBlob);
-
-      PRICES_DB = splitJsonBlob(jsonBlob, ninjaSchema);
+      priceIndex = new Map();
+      for (const section of overview.itemOverviews) {
+        const mapping = ninjaSchema.map.find((m) => m.type === section.type);
+        if (!mapping) continue;
+        for (const item of section.lines) {
+          const key = `${mapping.ns}:${item.name}:${item.variant ?? ""}`;
+          priceIndex.set(key, {
+            entry: item,
+            cx: mapping.cx,
+            url: mapping.url,
+          });
+        }
+      }
 
       // TODO: update to search for requested currency instead of divine
-      const divineRates = ninjaXchg.rates;
+      const divineRates = overview.core.rates;
       const preferred = selectedCoreCurrency.value;
 
       if (divineRates && Object.values(divineRates).some((v) => v >= 10)) {
@@ -257,32 +271,14 @@ export const usePoeninja = createGlobalState(() => {
   }
 
   function findPriceByQuery(query: DbQuery) {
-    // NOTE: order of keys is important
-    const searchString = JSON.stringify({
-      name: query.name,
-      variant: query.variant,
-      primaryValue: 0,
-    }).replace(":0}", ":");
-    const endSearchString = "}}";
-
-    for (const { ns, cx, url, lines } of PRICES_DB) {
-      if (ns !== query.ns) continue;
-
-      const startPos = lines.indexOf(searchString);
-      if (startPos === -1) continue;
-      const endPos = lines.indexOf(endSearchString, startPos);
-
-      const info: NinjaDenseExchangeInfo | NinjaDenseStashInfo = JSON.parse(
-        lines.slice(startPos, endPos + endSearchString.length),
-      );
-
-      return {
-        ...info,
-        cx,
-        url: `https://poe.ninja/poe2/economy/${selectedLeagueToUrl(false)}/${url}/${info.detailsId}`,
-      };
-    }
-    return null;
+    const key = `${query.ns}:${query.name}:${query.variant ?? ""}`;
+    const hit = priceIndex.get(key);
+    if (!hit) return null;
+    return {
+      ...hit.entry,
+      cx: hit.cx,
+      url: `https://poe.ninja/poe2/economy/${selectedLeagueToUrl(false)}/${hit.url}/${hit.entry.detailsId}`,
+    };
   }
 
   /**
@@ -362,7 +358,7 @@ export const usePoeninja = createGlobalState(() => {
 
   watch(leagues.selectedId, () => {
     xchgRate.value = undefined;
-    PRICES_DB = [];
+    priceIndex = new Map();
     load(true);
   });
 
@@ -370,7 +366,7 @@ export const usePoeninja = createGlobalState(() => {
     if (curr === prev) return;
     xchgRateCurrency.value = curr ?? "exalted";
     xchgRate.value = undefined;
-    PRICES_DB = [];
+    priceIndex = new Map();
     load(true);
   });
 
@@ -381,64 +377,11 @@ export const usePoeninja = createGlobalState(() => {
     autoCurrency,
     queuePricesFetch,
     cachedCurrencyByQuery,
-    initialLoading: () => isLoading.value && !PRICES_DB.length,
+    initialLoading: () => isLoading.value && !priceIndex.size,
     availableCoreCurrencies: readonly(availableCoreCurrencies),
     ITEM_DROP,
   };
 });
-
-function parseXchg(jsonBlob: string): NinjaXchgRates {
-  const RATES = '{"rates":';
-  const END_RATES = '"}';
-  const startPos = jsonBlob.indexOf(RATES);
-  const endPos = jsonBlob.indexOf(END_RATES, startPos) + END_RATES.length;
-  return JSON.parse(jsonBlob.slice(startPos, endPos));
-}
-
-function splitJsonBlob(jsonBlob: string, schema: NinjaSchema): PriceDatabase {
-  const NINJA_OVERVIEW = '{"type":"';
-  if (schema.schemaVersion !== 1) {
-    console.warn("Unsupported ninja schema version", schema.schemaVersion);
-    return [];
-  }
-  const NAMESPACE_MAP: Array<{
-    ns: string;
-    cx: boolean;
-    url: string;
-    type: string;
-  }> = schema.map;
-
-  const database: PriceDatabase = [];
-  let startPos = jsonBlob.indexOf(NINJA_OVERVIEW);
-  if (startPos === -1) return [];
-
-  while (true) {
-    const endPos = jsonBlob.indexOf(NINJA_OVERVIEW, startPos + 1);
-
-    const type = jsonBlob.slice(
-      startPos + NINJA_OVERVIEW.length,
-      jsonBlob.indexOf('"', startPos + NINJA_OVERVIEW.length),
-    );
-    const lines = jsonBlob.slice(
-      startPos,
-      endPos === -1 ? jsonBlob.length : endPos,
-    );
-
-    const isSupported = NAMESPACE_MAP.find((entry) => entry.type === type);
-    if (isSupported) {
-      database.push({
-        ns: isSupported.ns,
-        cx: isSupported.cx,
-        url: isSupported.url,
-        lines,
-      });
-    }
-
-    if (endPos === -1) break;
-    startPos = endPos;
-  }
-  return database;
-}
 
 export function displayRounding(
   value: number,
@@ -484,10 +427,3 @@ export function displayRounding(
   }
   return Math.round(value).toString();
 }
-
-// Disable since this is export for tests
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const __testExports = {
-  parseXchg,
-  splitJsonBlob,
-};

--- a/renderer/src/web/overlay/OverlayWindow.vue
+++ b/renderer/src/web/overlay/OverlayWindow.vue
@@ -93,6 +93,7 @@ export default defineComponent({
 
     const active = shallowRef(!Host.isElectron);
     const gameFocused = shallowRef(false);
+    const isWayland = shallowRef(false);
     const hideUI = shallowRef(false);
     const showEditingNotification = shallowRef(false);
 
@@ -133,6 +134,9 @@ export default defineComponent({
     Host.onEvent("MAIN->OVERLAY::focus-change", (state) => {
       active.value = state.overlay;
       gameFocused.value = state.game;
+      isWayland.value = state.isWayland;
+
+      if (state.isWayland) return;
 
       if (active.value === false) {
         for (const w of widgets.value) {
@@ -157,6 +161,12 @@ export default defineComponent({
     Host.onEvent("MAIN->CLIENT::game-log", (e) => {
       lineQueue.push(...e.lines);
       processQueue();
+    });
+    Host.onEvent("MAIN->CLIENT::show-settings", () => {
+      const settings = widgets.value.find((w) => w.wmType === "settings");
+      if (settings) {
+        show(settings.wmId);
+      }
     });
     function processQueue() {
       if (processing) return;
@@ -324,7 +334,12 @@ export default defineComponent({
     });
 
     function handleBackgroundClick() {
-      if (AppConfig().overlayAlwaysClose) {
+      if (Host.isElectron && isWayland.value) {
+        Host.sendEvent({
+          name: "OVERLAY->MAIN::focus-game",
+          payload: undefined,
+        });
+      } else if (AppConfig().overlayAlwaysClose) {
         Host.sendEvent({
           name: "OVERLAY->MAIN::focus-game",
           payload: undefined,

--- a/renderer/src/web/overlay/Widget.vue
+++ b/renderer/src/web/overlay/Widget.vue
@@ -229,7 +229,10 @@ export default defineComponent({
         "left": `${anchor.x}%`,
         "max-width": `${max.w}%`,
         "max-height": `${max.h}%`,
-        "transform": [translate, `translate(${clampOffset.value.x}px, ${clampOffset.value.y}px)`]
+        "transform": [
+          translate,
+          `translate(${clampOffset.value.x}px, ${clampOffset.value.y}px)`,
+        ]
           .filter(Boolean)
           .join(" "),
         "z-index": typeof wmZorder === "number" ? wmZorder : undefined,

--- a/renderer/src/web/overlay/Widget.vue
+++ b/renderer/src/web/overlay/Widget.vue
@@ -1,6 +1,7 @@
 <template>
   <div @mousedown="handleMouseDown">
     <div
+      ref="widgetEl"
       :class="[$style.widget, { 'opacity-75': isMoving }]"
       :style="widgetPosition"
     >
@@ -110,7 +111,17 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed, inject, ref } from "vue";
+import {
+  defineComponent,
+  PropType,
+  computed,
+  inject,
+  ref,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  watch,
+} from "vue";
 import { Widget, Anchor, WidgetManager } from "./interfaces";
 import { useI18n } from "vue-i18n";
 
@@ -162,6 +173,9 @@ export default defineComponent({
   },
   setup(props) {
     const wm = inject<WidgetManager>("wm")!;
+    const widgetEl = ref<HTMLElement | null>(null);
+    const clampOffset = ref({ x: 0, y: 0 });
+    let resizeObserver: ResizeObserver | undefined;
 
     const moverPosition = computed(() => {
       const { anchor, wmZorder } = props.config;
@@ -215,7 +229,9 @@ export default defineComponent({
         "left": `${anchor.x}%`,
         "max-width": `${max.w}%`,
         "max-height": `${max.h}%`,
-        "transform": translate,
+        "transform": [translate, `translate(${clampOffset.value.x}px, ${clampOffset.value.y}px)`]
+          .filter(Boolean)
+          .join(" "),
         "z-index": typeof wmZorder === "number" ? wmZorder : undefined,
       };
     });
@@ -292,8 +308,61 @@ export default defineComponent({
 
     const { t } = useI18n();
 
+    function updateClampOffset() {
+      const el = widgetEl.value;
+      if (!el) return;
+
+      clampOffset.value = { x: 0, y: 0 };
+      nextTick(() => {
+        const rect = el.getBoundingClientRect();
+        let x = 0;
+        let y = 0;
+
+        if (rect.left < 0) {
+          x = -rect.left;
+        } else if (rect.right > window.innerWidth) {
+          x = window.innerWidth - rect.right;
+        }
+
+        if (rect.top < 0) {
+          y = -rect.top;
+        } else if (rect.bottom > window.innerHeight) {
+          y = window.innerHeight - rect.bottom;
+        }
+
+        clampOffset.value = { x, y };
+      });
+    }
+
+    onMounted(() => {
+      resizeObserver = new ResizeObserver(updateClampOffset);
+      if (widgetEl.value) {
+        resizeObserver.observe(widgetEl.value);
+      }
+      window.addEventListener("resize", updateClampOffset);
+      updateClampOffset();
+    });
+
+    onUnmounted(() => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateClampOffset);
+    });
+
+    watch(
+      () => [
+        props.config.anchor.x,
+        props.config.anchor.y,
+        props.config.anchor.pos,
+        props.config.wmWants,
+        wm.size.value.width,
+        wm.size.value.height,
+      ],
+      () => nextTick(updateClampOffset),
+    );
+
     return {
       t,
+      widgetEl,
       moverPosition,
       widgetPosition,
       actionsPosition,

--- a/renderer/src/web/price-check/CheckPositionCircle.vue
+++ b/renderer/src/web/price-check/CheckPositionCircle.vue
@@ -35,9 +35,32 @@ const props = defineProps<{
 }>();
 
 const relativePos = computed(() => {
+  const localX = clampToViewport(props.position.x - screenOffsetX(), window.innerWidth);
+  const localY = clampToViewport(props.position.y - screenOffsetY(), window.innerHeight);
+
   return {
-    top: `calc(${props.position.y - window.screenY}px - 2.5rem)`,
-    left: `calc(${props.position.x - window.screenX}px - 2.5rem)`,
+    top: `calc(${localY}px - 2.5rem)`,
+    left: `calc(${localX}px - 2.5rem)`,
   };
 });
+
+function screenOffsetX() {
+  return isUsableScreenOffset(window.screenX, window.innerWidth)
+    ? window.screenX
+    : 0;
+}
+
+function screenOffsetY() {
+  return isUsableScreenOffset(window.screenY, window.innerHeight)
+    ? window.screenY
+    : 0;
+}
+
+function isUsableScreenOffset(offset: number, viewportSize: number) {
+  return Number.isFinite(offset) && offset >= 0 && offset <= viewportSize;
+}
+
+function clampToViewport(value: number, viewportSize: number) {
+  return Math.min(Math.max(value, 0), viewportSize);
+}
 </script>

--- a/renderer/src/web/price-check/CheckPositionCircle.vue
+++ b/renderer/src/web/price-check/CheckPositionCircle.vue
@@ -35,8 +35,14 @@ const props = defineProps<{
 }>();
 
 const relativePos = computed(() => {
-  const localX = clampToViewport(props.position.x - screenOffsetX(), window.innerWidth);
-  const localY = clampToViewport(props.position.y - screenOffsetY(), window.innerHeight);
+  const localX = clampToViewport(
+    props.position.x - screenOffsetX(),
+    window.innerWidth,
+  );
+  const localY = clampToViewport(
+    props.position.y - screenOffsetY(),
+    window.innerHeight,
+  );
 
   return {
     top: `calc(${localY}px - 2.5rem)`,

--- a/renderer/src/web/price-check/PriceCheckWindow.vue
+++ b/renderer/src/web/price-check/PriceCheckWindow.vue
@@ -167,6 +167,7 @@ import {
   nextTick,
   provide,
   ref,
+  onBeforeUnmount,
 } from "vue";
 import { Result, ok, err } from "neverthrow";
 import { useI18n } from "vue-i18n";
@@ -392,8 +393,19 @@ export default defineComponent({
       item.value = ok(identified);
     }
 
-    MainProcess.onEvent("MAIN->OVERLAY::hide-exclusive-widget", () => {
+    function resetPriceCheck() {
+      closeBrowser();
+      item.value = null;
+      itemEditorOptions.value = {
+        editing: false,
+        value: "None",
+        disabled: true,
+      };
       wm.hide(props.config.wmId);
+    }
+
+    MainProcess.onEvent("MAIN->OVERLAY::hide-exclusive-widget", () => {
+      resetPriceCheck();
     });
 
     watch(
@@ -442,20 +454,34 @@ export default defineComponent({
     });
 
     function closePriceCheck() {
-      if (AppConfig().overlayAlwaysClose) {
-        Host.sendEvent({
-          name: "OVERLAY->MAIN::focus-game",
-          payload: undefined,
-        });
-      } else if (isBrowserShown.value || !Host.isElectron) {
-        wm.hide(props.config.wmId);
-      } else {
+      const wasBrowserShown = isBrowserShown.value;
+      resetPriceCheck();
+
+      if (
+        Host.isElectron &&
+        (AppConfig().overlayAlwaysClose || !wasBrowserShown)
+      ) {
         Host.sendEvent({
           name: "OVERLAY->MAIN::focus-game",
           payload: undefined,
         });
       }
     }
+
+    function handleKeydown(e: KeyboardEvent) {
+      if (props.config.wmWants !== "show") return;
+      if (e.key !== "Escape" && !(e.ctrlKey && e.key.toLowerCase() === "w")) {
+        return;
+      }
+
+      e.preventDefault();
+      closePriceCheck();
+    }
+
+    window.addEventListener("keydown", handleKeydown);
+    onBeforeUnmount(() => {
+      window.removeEventListener("keydown", handleKeydown);
+    });
 
     function openLeagueSelection() {
       const settings = wm.widgets.value.find((w) => w.wmType === "settings")!;

--- a/renderer/src/web/settings/SettingsWindow.vue
+++ b/renderer/src/web/settings/SettingsWindow.vue
@@ -298,7 +298,7 @@ export default defineComponent({
       t,
       save() {
         updateConfig(configClone.value!);
-        saveConfig();
+        saveConfig({ force: true });
         pushHostConfig();
 
         wm.hide(props.config.wmId);


### PR DESCRIPTION
## Problem
Wayland is a new protocol for compositors on linux. Compositors will sometimes also be Display Managers which implement the Wayland protocol but not always. 

The Wayland protocol only sends key presses to a window that is in focus for security reasons.

A program is supposed to "request" global hot keys but not all compositors implement this ability yet and they do so in different ways which are all in beta in other words a moving target for compatibility and support across multiple linux distros. So not great.

## Solution
Run a small program as root and have it send only the key presses you want recreating the same Wayland security model by well basically bypassing it entirely. 

### Video
https://github.com/user-attachments/assets/369ecbb3-2f5c-4a30-9426-3bbe8386bcd0

# Major Changes

- Contains the other data fix [PR](https://github.com/Kvan7/Exiled-Exchange-2/pull/985) because I needed to use it for testing.

- This PR adds an npm package that I made specifically for Exiled Exchange 2. The package is linux-evdev-wayland-helper and it is open sourced here https://github.com/hparadiz/linux-evdev-wayland-helper

### How the Helper Works
- The linux-evdev-wayland-helper is launched by Exiled Exchange 2 during startup if it detects a Wayland session only.

> > <img width="632" height="196" alt="image" src="https://github.com/user-attachments/assets/b279ea18-e2b4-44a4-b98d-849a6bd0fe72" />

- The helper is bundled with the package and is self contained once Exiled Exchange 2 is packaged for release.
- The helper is a small program written in C less than 1000 lines of code.
- Exiled Exchange 2 launches the helper with pkexec.
- Pkexec is the GUI sudo password utility visibile in the screenshot.
- With this you get keypresses directly from the system. 
- This does not prevent the compositor from also receiving your click through. If you press your hotkey the game will also get the keybind until the overlay is open.


## Other Changes in the RP
* Began integrating the new Wayland hotkey helper in the shortcuts module (`Shortcuts.ts`), setting the stage for full migration off X11-dependent hotkey registration.
* Refactored config file saving logic in `ConfigStore` to avoid persistent state about temporary files and to simplify file path handling.




Can probably drop this
- Improved the Electron development workflow in `main/build/script.mjs` by adding remote debugging and persistent log file support for both Electron and Chromium. This helps with troubleshooting and development on Wayland and other platforms.

### More Wayland Technical Details Useful to Any Electron Dev on Wayland
- During my work I checked out the electron source code which is chromium based and written in C and I made a comprehensive break down of how Wayland and Electron work @ **docs/wayland.md**. In it you will find this table explaining how the JSON api behaves in Wayland. 
- 
#### Wayland Electron API Notes

| API | Wayland status | Notes |
|-----|---------------|-------|
| `show()` | Works | Requests focus via xdg_activation_v1; may fight fullscreen game |
| `showInactive()` | **Not supported** | Officially unsupported; undefined behavior |
| `focus()` | Works (if visible) | Sends activation request; causes focus battle with fullscreen game |
| `hide()` | Works | Clean surface unmap; compositor returns focus to previous window |
| `moveTop()` | **No-op** | No Wayland code path |
| `setAlwaysOnTop(true, level)` | Partial | Level string ignored; bool may have compositor-dependent effect |
| `setVisibleOnAllWorkspaces(true)` | Works | `visibleOnFullScreen` param is macOS-only, ignored on Linux |
| `setIgnoreMouseEvents(bool)` | **No-op** | No Wayland code path; use `hide()` instead |
| `globalShortcut.register()` | **Do not use** | Falls back to XGrabKey; double-fires with evdev helper, disrupts XWayland input |

### Screenshots

### Test Machine
<img width="763" height="292" alt="image" src="https://github.com/user-attachments/assets/d01caf89-3e73-40f2-bacf-a0b70dc17e99" />
<img width="459" height="459" alt="image" src="https://github.com/user-attachments/assets/06bf4da6-05d0-4ef6-83ba-1fa1ccc00a34" />