### PR TITLE
fix call of 'length' in undefined property

### DIFF
--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -1681,7 +1681,7 @@ function getTier(
 }
 
 function getTierV2(mods: FetchModInfo[]): string | undefined {
-  if (!mods.length) return;
+  if (!mods || !mods.length) return;
 
   return mods.map((mod) => mod.tier).join(" + ");
 }


### PR DESCRIPTION
@Kvan7
This should fix issue [979](https://github.com/Kvan7/Exiled-Exchange-2/issues/979).
My testing was made with "The Desperate Alliance" relic.

Before:
<img width="506" height="577" alt="image" src="https://github.com/user-attachments/assets/557c79bd-9c09-439e-8a67-0d0e19073296" />

After:
<img width="497" height="611" alt="image" src="https://github.com/user-attachments/assets/5bb37409-e923-45c3-ad10-796eb52f8251" />
