### PR TITLE
Add setting to prefer 'Base Item' preset on magic items

### DIFF
--- a/renderer/public/data/en/app_i18n.json
+++ b/renderer/public/data/en/app_i18n.json
@@ -420,6 +420,7 @@
     "show_suggest_warning_warn": "Show alert",
     "show_suggest_warning_help": "Show alert and help",
     "default_all_selected": "Default all filters to enabled",
+    "default_base_item_on_magic": "Default to \"Base item\" filter for magic items",
     "use_tooltip_hover": "Show item when hovering over price",
     "use_tooltip_keybind": "SHIFT + hover",
     "use_tooltip_always": "hover",

--- a/renderer/specs/vitest.setup.ts
+++ b/renderer/specs/vitest.setup.ts
@@ -54,7 +54,15 @@ export const setupFetchMock = () => {
       bodyUsed: false,
       json: async () => JSON.parse(body as string),
       text: async () => body,
-      arrayBuffer: async () => Buffer.from(body as string).buffer,
+      arrayBuffer: async () => {
+        const buffer = Buffer.isBuffer(body)
+          ? body
+          : Buffer.from(body as string);
+        return buffer.buffer.slice(
+          buffer.byteOffset,
+          buffer.byteOffset + buffer.byteLength,
+        );
+      },
       blob: async () => new Blob([body as string]),
       formData: async () => {
         throw new Error("formData not implemented");

--- a/renderer/src/web/Config.ts
+++ b/renderer/src/web/Config.ts
@@ -156,7 +156,7 @@ export interface Config {
 }
 
 export const defaultConfig = (): Config => ({
-  configVersion: 34,
+  configVersion: 35,
   overlayKey: "Shift + Space",
   overlayBackground: "rgba(129, 139, 149, 0.15)",
   overlayBackgroundClose: true,
@@ -668,6 +668,16 @@ function upgradeConfig(_config: Config): Config {
     libraryWidget.profiles.chaos!.modOpts.generation = true;
 
     config.configVersion = 34;
+  }
+
+  if (config.configVersion < 35) {
+    // NOTE: v0.15.9 || poe0.5.4b
+    const priceCheck = config.widgets.find(
+      (w) => w.wmType === "price-check",
+    ) as widget.PriceCheckWidget;
+    priceCheck.defaultBaseItemOnMagic = false;
+
+    config.configVersion = 35;
   }
   /* eslint-enable */
 

--- a/renderer/src/web/overlay/widgets.ts
+++ b/renderer/src/web/overlay/widgets.ts
@@ -52,6 +52,7 @@ export interface PriceCheckWidget extends Widget {
   builtinBrowser: boolean;
   rememberCurrency: boolean;
   defaultAllSelected: boolean;
+  defaultBaseItemOnMagic: boolean;
   itemHoverTooltip: "off" | "keybind" | "always";
   autoFillEmptyRuneSockets: "Iron Rune" | false;
   alwaysShowTier: boolean;

--- a/renderer/src/web/price-check/CheckedItem.vue
+++ b/renderer/src/web/price-check/CheckedItem.vue
@@ -181,6 +181,7 @@ export default defineComponent({
             ? prevListingType
             : undefined,
           defaultAllSelected: widget.value.defaultAllSelected,
+          defaultBaseItemOnMagic: widget.value.defaultBaseItemOnMagic,
           autoFillEmptyAugmentSockets: widget.value.autoFillEmptyRuneSockets,
         });
 

--- a/renderer/src/web/price-check/PriceCheckWindow.vue
+++ b/renderer/src/web/price-check/PriceCheckWindow.vue
@@ -238,6 +238,7 @@ export default defineComponent({
         rememberCurrency: false,
         // New Settings EE2
         defaultAllSelected: false,
+        defaultBaseItemOnMagic: false,
         itemHoverTooltip: "keybind",
         autoFillEmptyRuneSockets: false,
         alwaysShowTier: false,

--- a/renderer/src/web/price-check/filters/create-presets.ts
+++ b/renderer/src/web/price-check/filters/create-presets.ts
@@ -29,6 +29,7 @@ export function createPresets(
     searchStatRange: number;
     useEn: boolean;
     defaultAllSelected: boolean;
+    defaultBaseItemOnMagic: boolean;
     autoFillEmptyAugmentSockets: PriceCheckWidget["autoFillEmptyRuneSockets"];
   },
 ): { presets: FilterPreset[]; active: string } {
@@ -84,6 +85,9 @@ export function createPresets(
     stats: initUiModFilters(item, opts),
   };
 
+  const shouldDefaultBaseItemOnMagic =
+    opts.defaultBaseItemOnMagic && item.rarity === ItemRarity.Magic;
+
   // Apply augments if we should
   // if (
   //   (item.rarity === ItemRarity.Magic || item.rarity === ItemRarity.Rare) &&
@@ -99,7 +103,10 @@ export function createPresets(
   //   );
   // }
 
-  if (likelyFinishedItem(item) || !hasCraftingValue(item)) {
+  if (
+    (likelyFinishedItem(item) || !hasCraftingValue(item)) &&
+    !shouldDefaultBaseItemOnMagic
+  ) {
     return { active: pseudoPreset.id, presets: [pseudoPreset] };
   }
 
@@ -109,8 +116,12 @@ export function createPresets(
     stats: createExactStatFilters(item, item.statsByType, opts),
   };
 
+  const activePreset = shouldDefaultBaseItemOnMagic
+    ? baseItemPreset.id
+    : pseudoPreset.id;
+
   return {
-    active: pseudoPreset.id,
+    active: activePreset,
     presets: [pseudoPreset, baseItemPreset],
   };
 }

--- a/renderer/src/web/price-check/settings-price-check.vue
+++ b/renderer/src/web/price-check/settings-price-check.vue
@@ -181,6 +181,9 @@
     <ui-checkbox class="mb-4" v-model="defaultAllSelected">{{
       t(":default_all_selected")
     }}</ui-checkbox>
+    <ui-checkbox class="mb-4" v-model="defaultBaseItemOnMagic">{{
+      t(":default_base_item_on_magic")
+    }}</ui-checkbox>
     <ui-checkbox class="mb-4" v-model="alwaysShowTier">{{
       t(":always_show_tier")
     }}</ui-checkbox>
@@ -368,6 +371,10 @@ export default defineComponent({
       defaultAllSelected: configModelValue(
         () => configWidget.value,
         "defaultAllSelected",
+      ),
+      defaultBaseItemOnMagic: configModelValue(
+        () => configWidget.value,
+        "defaultBaseItemOnMagic",
       ),
       leagues,
       availableCoreCurrencies,


### PR DESCRIPTION
Naive implementation of an 'Prefer Base Item filter on magic items' setting.

Played with it for a bit and it was quite a big help already. 

A few open points: 
- Is this even needed to be configurable? Would there be harm in just falling back to the base item preset for magic items by default?  
- Translations missing
- I'm not super sure about the early return guard in line 108 in create-preset. I tried it with and without, and for some items (e.g. jewels) without the guard, the filter behaves not as expected, so I think having it in is better. There is certainly a more elegant solution to be found here tho. 
- Positioning in the settings can probably be improved, I just put it randomly, as I don't have a strong opinion here.

(Btw, took me a while to figure out file writes are disabled in dev mode, I thought I somehow broke the config saving 😅)